### PR TITLE
ENH: improvements and additions from XCS testing

### DIFF
--- a/las_dispersion_scan/bin/gui.py
+++ b/las_dispersion_scan/bin/gui.py
@@ -188,6 +188,9 @@ def main(
         logger.warning("Unable to select the qt5 backend for matplotlib", exc_info=True)
     plt.ion()
 
+    app.setOrganizationName("SLAC National Accelerator Laboratory")
+    app.setApplicationName("las-dispersion-scan")
+
     loader = Loader(
         script=script,
         stage=stage,

--- a/las_dispersion_scan/devices.py
+++ b/las_dispersion_scan/devices.py
@@ -66,6 +66,8 @@ class Qmini(qmini.QminiSpectrometer):
     spectrum = UCpt()
     wavelengths = UCpt()
 
+    wavelength_units = "nm"
+
     def stop(self):
         ...
 

--- a/las_dispersion_scan/dscan.py
+++ b/las_dispersion_scan/dscan.py
@@ -1411,7 +1411,7 @@ class PypretResult:
         """Final plot position for RetrievalResultPlot, in meters."""
         if self.plot_position is None:
             return self.scan.positions[self.optimum_fwhm_idx]
-        return self.plot_position
+        return self.plot_position * 1e-3
 
     def _get_retrieval_plot(self) -> RetrievalResultPlot:
         """

--- a/las_dispersion_scan/dscan.py
+++ b/las_dispersion_scan/dscan.py
@@ -1492,7 +1492,7 @@ class PypretResult:
         -------
         PypretResult
         """
-        return PypretResult(
+        return cls(
             fund=copy.deepcopy(fund),
             scan=copy.deepcopy(scan),
             material=material,

--- a/las_dispersion_scan/dscan.py
+++ b/las_dispersion_scan/dscan.py
@@ -696,6 +696,22 @@ class AcquisitionScan:
                 stage=self.stage,
                 spectrometer=self.spectrometer,
             )
+
+            spectra = [data.spectrum]
+
+            while not self._stop and len(spectra) < per_step_spectra:
+                spectrum = SpectrumData.from_device(
+                    self.spectrometer
+                ).intensities.tolist()
+
+                if spectrum == spectra[-1]:
+                    time.sleep(dwell_time)
+                    continue
+
+                spectra.append(spectrum)
+
+            data.spectrum = np.average(np.asarray(spectra), axis=0).tolist()
+
             if np.sum(data.spectrum) < 1e-6:
                 logger.warning(
                     "Retrying scan point %d (%g); spectra was all zero",

--- a/las_dispersion_scan/dscan.py
+++ b/las_dispersion_scan/dscan.py
@@ -650,6 +650,7 @@ class AcquisitionScan:
         self,
         positions: List[float],
         dwell_time: float,
+        per_step_spectra: int = 1,
         timeout: float = 30.0,
     ) -> Generator[ScanPointData, None, None]:
         """

--- a/las_dispersion_scan/dscan.py
+++ b/las_dispersion_scan/dscan.py
@@ -695,7 +695,7 @@ class AcquisitionScan:
                 stage=self.stage,
                 spectrometer=self.spectrometer,
             )
-            if np.sum(all_data[-1].spectrum) < 1e-6:
+            if np.sum(data.spectrum) < 1e-6:
                 logger.warning(
                     "Retrying scan point %d (%g); spectra zero" "point",
                     idx,

--- a/las_dispersion_scan/dscan.py
+++ b/las_dispersion_scan/dscan.py
@@ -849,7 +849,7 @@ class PypretResult:
         )
 
     def plot_mesh_data(
-        self, data: Optional[pypret.MeshData] = None, scan_padding_nm: int = 75
+        self, data: Optional[pypret.MeshData] = None, scan_padding_nm: int = 0
     ) -> pypret.MeshDataPlot:
         """
         Plot the mesh scan data.
@@ -878,7 +878,7 @@ class PypretResult:
         return md
 
     def plot_processed_scan(
-        self, *, fig: Optional[plt.Figure] = None, scan_padding_nm: int = 75
+        self, *, fig: Optional[plt.Figure] = None, scan_padding_nm: int = 0
     ) -> pypret.MeshDataPlot:
         """
         Plot the processed mesh scan data from ``self.trace``.
@@ -1194,7 +1194,7 @@ class PypretResult:
             ax.yaxis.set_major_formatter(fy)
 
         ax.set_title(title)
-        scan_padding = 75  # (nm)
+        scan_padding = 0  # (nm)
         ax.set_xlim(
             2.99792 * 1e17 / (self.spec_scan_range[1] - scan_padding),
             2.99792 * 1e17 / (self.spec_scan_range[0] + scan_padding),

--- a/las_dispersion_scan/dscan.py
+++ b/las_dispersion_scan/dscan.py
@@ -697,7 +697,7 @@ class AcquisitionScan:
             )
             if np.sum(data.spectrum) < 1e-6:
                 logger.warning(
-                    "Retrying scan point %d (%g); spectra zero" "point",
+                    "Retrying scan point %d (%g); spectra was all zero",
                     idx,
                     setpoint,
                 )
@@ -979,9 +979,8 @@ class PypretResult:
 
         fx = EngFormatter(unit="s")
         ax1.xaxis.set_major_formatter(fx)
-        ax1.set_title(
-            f"time domain @ {self._final_plot_position:.3f} mm (FWHM = {fwhm} fs)"
-        )
+        plot_position_mm = self._final_plot_position * 1e3
+        ax1.set_title(f"time domain @ {plot_position_mm:.3f} mm (FWHM = {fwhm} fs)")
         ax1.set_xlabel("time")
         ax1.set_ylabel(yaxis.value)
         ax12.set_ylabel("phase (rad)")
@@ -1392,7 +1391,7 @@ class PypretResult:
 
     @property
     def _final_plot_position(self):
-        """Final plot position for RetrievalResultPlot"""
+        """Final plot position for RetrievalResultPlot, in meters."""
         if self.plot_position is None:
             return self.scan.positions[self.optimum_fwhm_idx]
         return self.plot_position

--- a/las_dispersion_scan/loaders/qmini_and_epicsmotor.py
+++ b/las_dispersion_scan/loaders/qmini_and_epicsmotor.py
@@ -2,7 +2,8 @@ import os
 
 import ophyd
 
-from ..devices import Qmini
+# from ..devices import Qmini
+from las_dispersion_scan.devices import Qmini
 
 qmini_prefix = os.environ.get("QMINI_PREFIX", "LAS:XCS:QMINI:01")
 stage_prefix = os.environ.get("MOTOR_PREFIX", "IOC:TST:motor")

--- a/las_dispersion_scan/loaders/qmini_and_epicsmotor.py
+++ b/las_dispersion_scan/loaders/qmini_and_epicsmotor.py
@@ -1,0 +1,25 @@
+import os
+
+import ophyd
+
+from ..devices import Qmini
+
+qmini_prefix = os.environ.get("QMINI_PREFIX", "LAS:XCS:QMINI:01")
+stage_prefix = os.environ.get("MOTOR_PREFIX", "IOC:TST:motor")
+qmini_name = os.environ.get("QMINI_NAME", "xcs_las_mmn_02")
+stage_name = os.environ.get("MOTOR_NAME", "XCS:LAS:MMN:02")
+motor_units = os.environ.get("MOTOR_UNITS", "")
+
+spectrometer = Qmini(qmini_prefix, name=qmini_name)
+
+if motor_units:
+
+    class EpicsMotor(ophyd.EpicsMotor):
+        @property
+        def egu(self) -> str:
+            return motor_units
+
+else:
+    EpicsMotor = ophyd.EpicsMotor
+
+stage = EpicsMotor(stage_prefix, name=stage_name)

--- a/las_dispersion_scan/loaders/qmini_and_newport.py
+++ b/las_dispersion_scan/loaders/qmini_and_newport.py
@@ -1,0 +1,27 @@
+import os
+
+import pcdsdevices.epics_motor
+
+from las_dispersion_scan.devices import Qmini
+
+qmini_prefix = os.environ.get("QMINI_PREFIX", "LAS:XCS:QMINI:01")
+stage_prefix = os.environ.get("MOTOR_PREFIX", "IOC:TST:motor")
+qmini_name = os.environ.get("QMINI_NAME", "xcs_las_mmn_02")
+stage_name = os.environ.get("MOTOR_NAME", "XCS:LAS:MMN:02")
+motor_units = os.environ.get("MOTOR_UNITS", "")
+
+spectrometer = Qmini(qmini_prefix, name=qmini_name)
+
+if motor_units:
+
+    class Newport(pcdsdevices.epics_motor.Newport):
+        @property
+        def egu(self) -> str:
+            return motor_units
+
+else:
+    Newport = pcdsdevices.epics_motor.Newport
+
+stage = Newport(stage_prefix, name=stage_name)
+
+spectrometer.wavelength_units = "nm"

--- a/las_dispersion_scan/loaders/qmini_and_newport.py
+++ b/las_dispersion_scan/loaders/qmini_and_newport.py
@@ -23,5 +23,3 @@ else:
     Newport = pcdsdevices.epics_motor.Newport
 
 stage = Newport(stage_prefix, name=stage_name)
-
-spectrometer.wavelength_units = "nm"

--- a/las_dispersion_scan/plotting.py
+++ b/las_dispersion_scan/plotting.py
@@ -298,7 +298,7 @@ class RetrievalResultPlot:
                 ax.yaxis.set_major_formatter(fy)
 
             ax.set_title(title)
-            scan_padding = 75  # (nm)
+            scan_padding = 0  # (nm)
             ax.set_xlim(
                 [
                     2.99792 * 1e17 / (self.scan_range[1] - scan_padding),

--- a/las_dispersion_scan/plotting.py
+++ b/las_dispersion_scan/plotting.py
@@ -181,7 +181,8 @@ class RetrievalResultPlot:
 
         fx = EngFormatter(unit="s")
         ax1.xaxis.set_major_formatter(fx)
-        ax1.set_title(f"time domain @ {self.final_position:.3f} mm (FWHM = {fwhm} fs)")
+        plot_position_mm = self.final_position * 1e3
+        ax1.set_title(f"time domain @ {plot_position_mm:.3f} mm (FWHM = {fwhm} fs)")
         ax1.set_xlabel("time")
         ax1.set_ylabel(yaxis.value)
         ax12.set_ylabel("phase (rad)")

--- a/las_dispersion_scan/plotting.py
+++ b/las_dispersion_scan/plotting.py
@@ -101,6 +101,20 @@ def plot_complex_phase(
 
 @dataclasses.dataclass
 class RetrievalResultPlot:
+    """
+    This plot is only used for the "debug" mode.
+
+    It represents the original pypret-style plotting mechanism, with everything
+    summarized in one figure.
+
+    No effort was made to split/refactor these plots in this class. However,
+    the :class:`las_dispersion_scan.dscan.PypretResult` methods are separated
+    into individual plots.
+
+    This entire class can be considered deprecated, (if there even is such a
+    thing for a tool like this.)
+    """
+
     retrieval_result: RetrievalResultStandin
     retrieval_parameter: float
     fund_range: Tuple[float, float]

--- a/las_dispersion_scan/tests/simioc_loader.py
+++ b/las_dispersion_scan/tests/simioc_loader.py
@@ -3,4 +3,5 @@ import ophyd
 from ..devices import Qmini
 
 spectrometer = Qmini("IOC:TST:DScan:Qmini", name="sim-qmini")
+spectrometer.wavelength_units = "m"
 stage = ophyd.EpicsMotor("IOC:TST:DScan:m1", name="sim-m1")

--- a/las_dispersion_scan/ui/main.ui
+++ b/las_dispersion_scan/ui/main.ui
@@ -27,42 +27,6 @@
        </size>
       </property>
       <layout class="QGridLayout" name="plot_grid_layout">
-       <item row="21" column="0">
-        <widget class="QLabel" name="center_banwidth_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Bandwidth around center wavelength for frequency and time axes (nm)</string>
-         </property>
-         <property name="text">
-          <string>Center bandwidth</string>
-         </property>
-         <property name="buddy">
-          <cstring>freq_bandwidth_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="2">
-        <widget class="PyDMLabel" name="spectrometer_status_label">
-         <property name="toolTip">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="30" column="1">
-        <widget class="QCheckBox" name="phase_blanking_checkbox">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
        <item row="20" column="0">
         <widget class="QLabel" name="fundamental_range_label">
          <property name="sizePolicy">
@@ -82,6 +46,108 @@
          </property>
         </widget>
        </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="start_pos_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Scan range</string>
+         </property>
+         <property name="buddy">
+          <cstring>scan_start_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="25" column="1" colspan="2">
+        <widget class="SolverComboBox" name="solver_combo"/>
+       </item>
+       <item row="0" column="0" colspan="3">
+        <widget class="QLabel" name="params_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Scan parameters</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="0" colspan="3">
+        <widget class="QProgressBar" name="scan_progress">
+         <property name="value">
+          <number>24</number>
+         </property>
+         <property name="textVisible">
+          <bool>true</bool>
+         </property>
+         <property name="invertedAppearance">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QDoubleSpinBox" name="scan_start_spinbox">
+         <property name="suffix">
+          <string> mm</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>-10000000000.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>10000000000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>23.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="30" column="1">
+        <widget class="QCheckBox" name="phase_blanking_checkbox">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="21" column="0">
+        <widget class="QLabel" name="center_banwidth_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Bandwidth around center wavelength for frequency and time axes (nm)</string>
+         </property>
+         <property name="text">
+          <string>Center bandwidth</string>
+         </property>
+         <property name="buddy">
+          <cstring>freq_bandwidth_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
        <item row="8" column="0">
         <widget class="QLabel" name="dwell_time_label">
          <property name="sizePolicy">
@@ -98,13 +164,92 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
-        <widget class="TyphosRelatedSuiteButton" name="stage_suite_button">
-         <property name="toolTip">
-          <string/>
+       <item row="1" column="0">
+        <widget class="QLabel" name="stage_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
          <property name="text">
-          <string>stage_name</string>
+          <string>Stage</string>
+         </property>
+         <property name="buddy">
+          <cstring>stage_suite_button</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="32" column="0">
+        <widget class="QLabel" name="debug_mode_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Phase blanking threshold</string>
+         </property>
+         <property name="text">
+          <string>Debug mode</string>
+         </property>
+         <property name="buddy">
+          <cstring>debug_mode_checkbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="25" column="0">
+        <widget class="QLabel" name="solver_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>The retriever solver to use. </string>
+         </property>
+         <property name="text">
+          <string>Solver</string>
+         </property>
+         <property name="buddy">
+          <cstring>solver_combo</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="31" column="1" colspan="2">
+        <widget class="QDoubleSpinBox" name="phase_blanking_threshold_spinbox">
+         <property name="suffix">
+          <string/>
+         </property>
+         <property name="decimals">
+          <number>6</number>
+         </property>
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>100000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>0.010000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="scan_wavelength_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Wavelengths</string>
+         </property>
+         <property name="buddy">
+          <cstring>scan_wavelength_low_spinbox</cstring>
          </property>
         </widget>
        </item>
@@ -128,6 +273,228 @@
          </property>
         </widget>
        </item>
+       <item row="26" column="2">
+        <widget class="QPushButton" name="export_button">
+         <property name="toolTip">
+          <string>Export data to a file</string>
+         </property>
+         <property name="text">
+          <string>Export</string>
+         </property>
+        </widget>
+       </item>
+       <item row="24" column="1" colspan="2">
+        <widget class="PulseAnalysisComboBox" name="pulse_analysis_combo">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QSpinBox" name="scan_steps_spinbox">
+         <property name="minimum">
+          <number>5</number>
+         </property>
+         <property name="maximum">
+          <number>10000</number>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="QSpinBox" name="spectra_per_step_spinbox">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>100</number>
+         </property>
+         <property name="value">
+          <number>1</number>
+         </property>
+        </widget>
+       </item>
+       <item row="22" column="0">
+        <widget class="QLabel" name="material_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>The material used in the d-scan.
+</string>
+         </property>
+         <property name="text">
+          <string>Material</string>
+         </property>
+         <property name="buddy">
+          <cstring>material_combo</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="23" column="0">
+        <widget class="QLabel" name="nonlinear_process_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>The non-linear process to use
+</string>
+         </property>
+         <property name="text">
+          <string>Non-linear process</string>
+         </property>
+         <property name="buddy">
+          <cstring>nonlinear_combo</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="17" column="1" colspan="2">
+        <widget class="QSpinBox" name="blur_sigma_spinbox">
+         <property name="suffix">
+          <string> stdev</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <widget class="QDoubleSpinBox" name="dwell_time_spinbox">
+         <property name="suffix">
+          <string> sec</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>1000000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>0.100000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="19" column="0">
+        <widget class="QLabel" name="iterations_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Maximum number of iterations for the retriever</string>
+         </property>
+         <property name="text">
+          <string>Iterations</string>
+         </property>
+         <property name="buddy">
+          <cstring>iterations_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="scan_steps_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Scan steps</string>
+         </property>
+         <property name="buddy">
+          <cstring>scan_steps_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="32" column="1">
+        <widget class="QCheckBox" name="debug_mode_checkbox">
+         <property name="toolTip">
+          <string>Show all available debug plots in separate windows after pulse retrieval</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="PyDMLabel" name="stage_status_label">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="precision" stdset="0">
+          <number>3</number>
+         </property>
+         <property name="showUnits" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="precisionFromPV" stdset="0">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="18" column="0">
+        <widget class="QLabel" name="grid_points_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Number of grid points in frequency and time axes.
+</string>
+         </property>
+         <property name="text">
+          <string>Grid points</string>
+         </property>
+         <property name="buddy">
+          <cstring>num_grid_points_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="20" column="2">
+        <widget class="QDoubleSpinBox" name="fundamental_high_spinbox">
+         <property name="suffix">
+          <string> nm</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>1000000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>900.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="18" column="1" colspan="2">
+        <widget class="QSpinBox" name="num_grid_points_spinbox">
+         <property name="minimum">
+          <number>10</number>
+         </property>
+         <property name="maximum">
+          <number>100000</number>
+         </property>
+         <property name="value">
+          <number>3000</number>
+         </property>
+        </widget>
+       </item>
        <item row="20" column="1">
         <widget class="QDoubleSpinBox" name="fundamental_low_spinbox">
          <property name="suffix">
@@ -147,26 +514,42 @@
          </property>
         </widget>
        </item>
-       <item row="24" column="1" colspan="2">
-        <widget class="PulseAnalysisComboBox" name="pulse_analysis_combo">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="scan_wavelength_label">
+       <item row="29" column="0">
+        <widget class="QLabel" name="oversampling_label">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
+         <property name="toolTip">
+          <string>Oversampling</string>
+         </property>
          <property name="text">
-          <string>Wavelengths</string>
+          <string>Oversampling</string>
          </property>
          <property name="buddy">
-          <cstring>scan_wavelength_low_spinbox</cstring>
+          <cstring>oversampling_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="PyDMLabel" name="spectrometer_status_label">
+         <property name="toolTip">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="1">
+        <widget class="QPushButton" name="take_fundamental_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Take fundamental</string>
          </property>
         </widget>
        </item>
@@ -192,35 +575,140 @@
          </property>
         </widget>
        </item>
-       <item row="32" column="1">
-        <widget class="QCheckBox" name="debug_mode_checkbox">
-         <property name="toolTip">
-          <string>Show all available debug plots in separate windows after pulse retrieval</string>
+       <item row="13" column="0" colspan="3">
+        <widget class="QLabel" name="scan_status_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
          <property name="text">
-          <string/>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
+          <string>Scan: not in progress</string>
          </property>
         </widget>
        </item>
-       <item row="4" column="2">
-        <widget class="QDoubleSpinBox" name="scan_wavelength_high_spinbox">
-         <property name="suffix">
-          <string> nm</string>
+       <item row="24" column="0">
+        <widget class="QLabel" name="pulse_analysis_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
-         <property name="decimals">
-          <number>3</number>
+         <property name="toolTip">
+          <string>The pulse analysis method to use
+</string>
          </property>
+         <property name="text">
+          <string>Pulse analysis</string>
+         </property>
+         <property name="buddy">
+          <cstring>pulse_analysis_combo</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="17" column="0">
+        <widget class="QLabel" name="blur_sigma_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Strength of Gaussian blur applied to raw data (standard deviations).
+</string>
+         </property>
+         <property name="text">
+          <string>Blur sigma</string>
+         </property>
+         <property name="buddy">
+          <cstring>blur_sigma_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="2">
+        <widget class="QPushButton" name="scan_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>&amp;Start scan</string>
+         </property>
+        </widget>
+       </item>
+       <item row="29" column="1" colspan="2">
+        <widget class="QSpinBox" name="oversampling_spinbox">
          <property name="minimum">
-          <double>0.000000000000000</double>
+          <number>0</number>
          </property>
          <property name="maximum">
-          <double>100000.000000000000000</double>
+          <number>10000</number>
          </property>
          <property name="value">
-          <double>450.000000000000000</double>
+          <number>8</number>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="0">
+        <widget class="QCheckBox" name="save_automatically_checkbox">
+         <property name="toolTip">
+          <string>Save scan data automatically (in npz format) to the specified directory</string>
+         </property>
+         <property name="text">
+          <string>Auto save</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="per_step_spectra_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Per-step spectra</string>
+         </property>
+         <property name="buddy">
+          <cstring>scan_steps_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="19" column="1" colspan="2">
+        <widget class="QSpinBox" name="iterations_spinbox">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>10000</number>
+         </property>
+         <property name="value">
+          <number>30</number>
+         </property>
+        </widget>
+       </item>
+       <item row="30" column="0">
+        <widget class="QLabel" name="phase_blanking_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Enable phase blanking with pypret masking</string>
+         </property>
+         <property name="text">
+          <string>Phase blanking</string>
+         </property>
+         <property name="buddy">
+          <cstring>phase_blanking_checkbox</cstring>
          </property>
         </widget>
        </item>
@@ -243,206 +731,8 @@
          </property>
         </widget>
        </item>
-       <item row="17" column="1" colspan="2">
-        <widget class="QSpinBox" name="blur_sigma_spinbox">
-         <property name="suffix">
-          <string> stdev</string>
-         </property>
-        </widget>
-       </item>
-       <item row="12" column="0" colspan="3">
-        <widget class="QProgressBar" name="scan_progress">
-         <property name="value">
-          <number>24</number>
-         </property>
-         <property name="textVisible">
-          <bool>true</bool>
-         </property>
-         <property name="invertedAppearance">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="1">
-        <widget class="QDoubleSpinBox" name="dwell_time_spinbox">
-         <property name="suffix">
-          <string> sec</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>0.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>1000000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>0.100000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="scan_steps_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Scan steps</string>
-         </property>
-         <property name="buddy">
-          <cstring>scan_steps_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="26" column="1">
-        <widget class="QPushButton" name="import_button">
-         <property name="toolTip">
-          <string>Import data from previous scans</string>
-         </property>
-         <property name="text">
-          <string>Import</string>
-         </property>
-        </widget>
-       </item>
-       <item row="34" column="1">
-        <spacer name="left_spacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="26" column="2">
-        <widget class="QPushButton" name="export_button">
-         <property name="toolTip">
-          <string>Export data to a file</string>
-         </property>
-         <property name="text">
-          <string>Export</string>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="0">
-        <widget class="QCheckBox" name="save_automatically_checkbox">
-         <property name="toolTip">
-          <string>Save scan data automatically (in npz format) to the specified directory</string>
-         </property>
-         <property name="text">
-          <string>Auto save</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="2">
-        <widget class="QDoubleSpinBox" name="scan_end_spinbox">
-         <property name="suffix">
-          <string> mm</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>-10000000000.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>10000000000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>25.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="32" column="0">
-        <widget class="QLabel" name="debug_mode_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Phase blanking threshold</string>
-         </property>
-         <property name="text">
-          <string>Debug mode</string>
-         </property>
-         <property name="buddy">
-          <cstring>debug_mode_checkbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="spectrometer_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Spectrometer</string>
-         </property>
-         <property name="buddy">
-          <cstring>spectrometer_suite_button</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QDoubleSpinBox" name="scan_wavelength_low_spinbox">
-         <property name="suffix">
-          <string> nm</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>0.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>1000000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>350.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="QSpinBox" name="scan_steps_spinbox">
-         <property name="minimum">
-          <number>5</number>
-         </property>
-         <property name="maximum">
-          <number>10000</number>
-         </property>
-        </widget>
-       </item>
-       <item row="18" column="0">
-        <widget class="QLabel" name="grid_points_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Number of grid points in frequency and time axes.
-</string>
-         </property>
-         <property name="text">
-          <string>Grid points</string>
-         </property>
-         <property name="buddy">
-          <cstring>num_grid_points_spinbox</cstring>
-         </property>
-        </widget>
+       <item row="23" column="1" colspan="2">
+        <widget class="NonlinearComboBox" name="nonlinear_combo"/>
        </item>
        <item row="28" column="0">
         <widget class="QLabel" name="apply_limit_label">
@@ -464,87 +754,22 @@
          </property>
         </widget>
        </item>
-       <item row="19" column="0">
-        <widget class="QLabel" name="iterations_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+       <item row="21" column="1" colspan="2">
+        <widget class="QDoubleSpinBox" name="freq_bandwidth_spinbox">
+         <property name="suffix">
+          <string> nm</string>
          </property>
-         <property name="toolTip">
-          <string>Maximum number of iterations for the retriever</string>
+         <property name="decimals">
+          <number>3</number>
          </property>
-         <property name="text">
-          <string>Iterations</string>
-         </property>
-         <property name="buddy">
-          <cstring>iterations_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="29" column="1" colspan="2">
-        <widget class="QSpinBox" name="oversampling_spinbox">
          <property name="minimum">
-          <number>0</number>
+          <double>0.000000000000000</double>
          </property>
          <property name="maximum">
-          <number>10000</number>
+          <double>100000.000000000000000</double>
          </property>
          <property name="value">
-          <number>8</number>
-         </property>
-        </widget>
-       </item>
-       <item row="23" column="0">
-        <widget class="QLabel" name="nonlinear_process_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>The non-linear process to use
-</string>
-         </property>
-         <property name="text">
-          <string>Non-linear process</string>
-         </property>
-         <property name="buddy">
-          <cstring>nonlinear_combo</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="18" column="1" colspan="2">
-        <widget class="QSpinBox" name="num_grid_points_spinbox">
-         <property name="minimum">
-          <number>10</number>
-         </property>
-         <property name="maximum">
-          <number>100000</number>
-         </property>
-         <property name="value">
-          <number>3000</number>
-         </property>
-        </widget>
-       </item>
-       <item row="22" column="1" colspan="2">
-        <widget class="MaterialComboBox" name="material_combo"/>
-       </item>
-       <item row="23" column="1" colspan="2">
-        <widget class="NonlinearComboBox" name="nonlinear_combo"/>
-       </item>
-       <item row="9" column="2">
-        <widget class="QPushButton" name="scan_button">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>&amp;Start scan</string>
+          <double>800.000000000000000</double>
          </property>
         </widget>
        </item>
@@ -558,96 +783,19 @@
          </property>
         </widget>
        </item>
-       <item row="9" column="1">
-        <widget class="QPushButton" name="take_fundamental_button">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Take fundamental</string>
-         </property>
-        </widget>
-       </item>
-       <item row="16" column="1" colspan="2">
-        <widget class="QDoubleSpinBox" name="wedge_angle_spin">
-         <property name="suffix">
-          <string> deg</string>
-         </property>
-         <property name="decimals">
-          <number>5</number>
-         </property>
-         <property name="minimum">
-          <double>-360.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>360.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>8.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="25" column="0">
-        <widget class="QLabel" name="solver_label">
+       <item row="2" column="0">
+        <widget class="QLabel" name="spectrometer_label">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="toolTip">
-          <string>The retriever solver to use. </string>
-         </property>
          <property name="text">
-          <string>Solver</string>
+          <string>Spectrometer</string>
          </property>
          <property name="buddy">
-          <cstring>solver_combo</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="33" column="2">
-        <widget class="QPushButton" name="replot_button">
-         <property name="toolTip">
-          <string>Export data to a file</string>
-         </property>
-         <property name="text">
-          <string>Replot</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0" colspan="3">
-        <widget class="QLabel" name="params_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Scan parameters</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
-        <widget class="TyphosRelatedSuiteButton" name="spectrometer_suite_button">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="text">
-          <string>spectrometer_name</string>
+          <cstring>spectrometer_suite_button</cstring>
          </property>
         </widget>
        </item>
@@ -673,153 +821,8 @@
          </property>
         </widget>
        </item>
-       <item row="19" column="1" colspan="2">
-        <widget class="QSpinBox" name="iterations_spinbox">
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>10000</number>
-         </property>
-         <property name="value">
-          <number>30</number>
-         </property>
-        </widget>
-       </item>
-       <item row="29" column="0">
-        <widget class="QLabel" name="oversampling_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Oversampling</string>
-         </property>
-         <property name="text">
-          <string>Oversampling</string>
-         </property>
-         <property name="buddy">
-          <cstring>oversampling_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="2">
-        <widget class="PyDMLabel" name="stage_status_label">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="precision" stdset="0">
-          <number>3</number>
-         </property>
-         <property name="showUnits" stdset="0">
-          <bool>true</bool>
-         </property>
-         <property name="precisionFromPV" stdset="0">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="22" column="0">
-        <widget class="QLabel" name="material_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>The material used in the d-scan.
-</string>
-         </property>
-         <property name="text">
-          <string>Material</string>
-         </property>
-         <property name="buddy">
-          <cstring>material_combo</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="stage_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Stage</string>
-         </property>
-         <property name="buddy">
-          <cstring>stage_suite_button</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QDoubleSpinBox" name="scan_start_spinbox">
-         <property name="suffix">
-          <string> mm</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>-10000000000.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>10000000000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>23.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="24" column="0">
-        <widget class="QLabel" name="pulse_analysis_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>The pulse analysis method to use
-</string>
-         </property>
-         <property name="text">
-          <string>Pulse analysis</string>
-         </property>
-         <property name="buddy">
-          <cstring>pulse_analysis_combo</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="25" column="1" colspan="2">
-        <widget class="SolverComboBox" name="solver_combo"/>
-       </item>
-       <item row="30" column="0">
-        <widget class="QLabel" name="phase_blanking_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Enable phase blanking with pypret masking</string>
-         </property>
-         <property name="text">
-          <string>Phase blanking</string>
-         </property>
-         <property name="buddy">
-          <cstring>phase_blanking_checkbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="20" column="2">
-        <widget class="QDoubleSpinBox" name="fundamental_high_spinbox">
+       <item row="4" column="1">
+        <widget class="QDoubleSpinBox" name="scan_wavelength_low_spinbox">
          <property name="suffix">
           <string> nm</string>
          </property>
@@ -833,12 +836,22 @@
           <double>1000000.000000000000000</double>
          </property>
          <property name="value">
-          <double>900.000000000000000</double>
+          <double>350.000000000000000</double>
          </property>
         </widget>
        </item>
-       <item row="21" column="1" colspan="2">
-        <widget class="QDoubleSpinBox" name="freq_bandwidth_spinbox">
+       <item row="26" column="1">
+        <widget class="QPushButton" name="import_button">
+         <property name="toolTip">
+          <string>Import data from previous scans</string>
+         </property>
+         <property name="text">
+          <string>Import</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="2">
+        <widget class="QDoubleSpinBox" name="scan_wavelength_high_spinbox">
          <property name="suffix">
           <string> nm</string>
          </property>
@@ -852,104 +865,117 @@
           <double>100000.000000000000000</double>
          </property>
          <property name="value">
-          <double>800.000000000000000</double>
+          <double>450.000000000000000</double>
          </property>
         </widget>
        </item>
-       <item row="17" column="0">
-        <widget class="QLabel" name="blur_sigma_label">
+       <item row="1" column="1">
+        <widget class="TyphosRelatedSuiteButton" name="stage_suite_button">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="text">
+          <string>stage_name</string>
+         </property>
+        </widget>
+       </item>
+       <item row="22" column="1" colspan="2">
+        <widget class="MaterialComboBox" name="material_combo"/>
+       </item>
+       <item row="34" column="1">
+        <spacer name="left_spacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="16" column="1" colspan="2">
+        <widget class="QDoubleSpinBox" name="wedge_angle_spin">
+         <property name="suffix">
+          <string> deg</string>
+         </property>
+         <property name="decimals">
+          <number>5</number>
+         </property>
+         <property name="minimum">
+          <double>-360.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>360.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>8.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="2">
+        <widget class="QDoubleSpinBox" name="scan_end_spinbox">
+         <property name="suffix">
+          <string> mm</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>-10000000000.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>10000000000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>25.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="TyphosRelatedSuiteButton" name="spectrometer_suite_button">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="text">
+          <string>spectrometer_name</string>
+         </property>
+        </widget>
+       </item>
+       <item row="33" column="2">
+        <widget class="QPushButton" name="save_plots_button">
+         <property name="toolTip">
+          <string>Export data to a file</string>
+         </property>
+         <property name="text">
+          <string>Save plots</string>
+         </property>
+        </widget>
+       </item>
+       <item row="26" column="0">
+        <widget class="QPushButton" name="update_button">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
          <property name="toolTip">
-          <string>Strength of Gaussian blur applied to raw data (standard deviations).
-</string>
+          <string>Recalculate using the current retriever settings</string>
          </property>
          <property name="text">
-          <string>Blur sigma</string>
-         </property>
-         <property name="buddy">
-          <cstring>blur_sigma_spinbox</cstring>
+          <string>Recalculate</string>
          </property>
         </widget>
        </item>
-       <item row="13" column="0" colspan="3">
-        <widget class="QLabel" name="scan_status_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+       <item row="33" column="0">
+        <widget class="QPushButton" name="replot_button">
+         <property name="toolTip">
+          <string>Export data to a file</string>
          </property>
          <property name="text">
-          <string>Scan: not in progress</string>
-         </property>
-        </widget>
-       </item>
-       <item row="31" column="1" colspan="2">
-        <widget class="QDoubleSpinBox" name="phase_blanking_threshold_spinbox">
-         <property name="suffix">
-          <string/>
-         </property>
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>0.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>100000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>0.010000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="start_pos_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Scan range</string>
-         </property>
-         <property name="buddy">
-          <cstring>scan_start_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="per_step_spectra_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Per-step spectra</string>
-         </property>
-         <property name="buddy">
-          <cstring>scan_steps_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="1">
-        <widget class="QSpinBox" name="spectra_per_step_spinbox">
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>100</number>
-         </property>
-         <property name="value">
-          <number>1</number>
+          <string>Replot</string>
          </property>
         </widget>
        </item>
@@ -1167,22 +1193,6 @@
            </property>
           </widget>
          </item>
-         <item>
-          <widget class="QPushButton" name="update_button">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="toolTip">
-            <string>Recalculate using the current retriever settings</string>
-           </property>
-           <property name="text">
-            <string>Recalculate</string>
-           </property>
-          </widget>
-         </item>
         </layout>
        </item>
       </layout>
@@ -1259,6 +1269,7 @@
   <tabstop>nonlinear_combo</tabstop>
   <tabstop>pulse_analysis_combo</tabstop>
   <tabstop>solver_combo</tabstop>
+  <tabstop>update_button</tabstop>
   <tabstop>import_button</tabstop>
   <tabstop>export_button</tabstop>
   <tabstop>apply_limit_checkbox</tabstop>
@@ -1267,13 +1278,13 @@
   <tabstop>oversampling_spinbox</tabstop>
   <tabstop>debug_mode_checkbox</tabstop>
   <tabstop>replot_button</tabstop>
+  <tabstop>save_plots_button</tabstop>
   <tabstop>acquired_radio</tabstop>
   <tabstop>retrieved_radio</tabstop>
   <tabstop>difference_radio</tabstop>
   <tabstop>time_radio</tabstop>
   <tabstop>frequency_radio</tabstop>
   <tabstop>pulse_length_lineedit</tabstop>
-  <tabstop>update_button</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/las_dispersion_scan/ui/main.ui
+++ b/las_dispersion_scan/ui/main.ui
@@ -459,7 +459,7 @@
           <double>100000.000000000000000</double>
          </property>
          <property name="value">
-          <double>950.000000000000000</double>
+          <double>800.000000000000000</double>
          </property>
         </widget>
        </item>
@@ -504,7 +504,7 @@
           <string>Save scan data automatically (in npz format) to the specified directory</string>
          </property>
          <property name="text">
-          <string>Save automatically</string>
+          <string>Auto save</string>
          </property>
         </widget>
        </item>

--- a/las_dispersion_scan/ui/main.ui
+++ b/las_dispersion_scan/ui/main.ui
@@ -155,7 +155,7 @@
           <double>10000000000.000000000000000</double>
          </property>
          <property name="value">
-          <double>20.000000000000000</double>
+          <double>25.000000000000000</double>
          </property>
         </widget>
        </item>
@@ -238,7 +238,7 @@
           <double>1000000.000000000000000</double>
          </property>
          <property name="value">
-          <double>200.000000000000000</double>
+          <double>350.000000000000000</double>
          </property>
         </widget>
        </item>
@@ -284,7 +284,7 @@
           <double>100000.000000000000000</double>
          </property>
          <property name="value">
-          <double>400.000000000000000</double>
+          <double>700.000000000000000</double>
          </property>
         </widget>
        </item>
@@ -338,7 +338,7 @@
           <double>10000000000.000000000000000</double>
          </property>
          <property name="value">
-          <double>0.000000000000000</double>
+          <double>23.000000000000000</double>
          </property>
         </widget>
        </item>
@@ -654,7 +654,7 @@
           <double>100000.000000000000000</double>
          </property>
          <property name="value">
-          <double>300.000000000000000</double>
+          <double>450.000000000000000</double>
          </property>
         </widget>
        </item>
@@ -673,7 +673,7 @@
           <double>1000000.000000000000000</double>
          </property>
          <property name="value">
-          <double>600.000000000000000</double>
+          <double>900.000000000000000</double>
          </property>
         </widget>
        </item>
@@ -1136,14 +1136,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>PyDMLabel</class>
-   <extends>QLabel</extends>
-   <header>pydm.widgets.label</header>
-  </customwidget>
-  <customwidget>
    <class>TyphosRelatedSuiteButton</class>
    <extends>QPushButton</extends>
    <header>typhos.related_display</header>
+  </customwidget>
+  <customwidget>
+   <class>PyDMLabel</class>
+   <extends>QLabel</extends>
+   <header>pydm.widgets.label</header>
   </customwidget>
   <customwidget>
    <class>PlotWidget</class>

--- a/las_dispersion_scan/ui/main.ui
+++ b/las_dispersion_scan/ui/main.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1235</width>
-    <height>968</height>
+    <height>1020</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,27 +27,21 @@
        </size>
       </property>
       <layout class="QGridLayout" name="plot_grid_layout">
-       <item row="20" column="0">
-        <widget class="QLabel" name="fundamental_range_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
+       <item row="34" column="1">
+        <widget class="QCheckBox" name="debug_mode_checkbox">
          <property name="toolTip">
-          <string>Fundamental spectrum window</string>
+          <string>Show all available debug plots in separate windows after pulse retrieval</string>
          </property>
          <property name="text">
-          <string>Fundamental range</string>
+          <string/>
          </property>
-         <property name="buddy">
-          <cstring>fundamental_low_spinbox</cstring>
+         <property name="checked">
+          <bool>false</bool>
          </property>
         </widget>
        </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="start_pos_label">
+       <item row="1" column="0">
+        <widget class="QLabel" name="stage_label">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -55,17 +49,151 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>Scan range</string>
+          <string>Stage</string>
          </property>
          <property name="buddy">
-          <cstring>scan_start_spinbox</cstring>
+          <cstring>stage_suite_button</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="PyDMLabel" name="spectrometer_status_label">
+         <property name="toolTip">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="28" column="1">
+        <widget class="QPushButton" name="import_button">
+         <property name="toolTip">
+          <string>Import data from previous scans</string>
+         </property>
+         <property name="text">
+          <string>Import</string>
+         </property>
+        </widget>
+       </item>
+       <item row="19" column="1" colspan="2">
+        <widget class="QSpinBox" name="blur_sigma_spinbox">
+         <property name="suffix">
+          <string> stdev</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="scan_wavelength_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Wavelengths</string>
+         </property>
+         <property name="buddy">
+          <cstring>scan_wavelength_low_spinbox</cstring>
          </property>
         </widget>
        </item>
        <item row="25" column="1" colspan="2">
+        <widget class="NonlinearComboBox" name="nonlinear_combo"/>
+       </item>
+       <item row="2" column="1">
+        <widget class="TyphosRelatedSuiteButton" name="spectrometer_suite_button">
+         <property name="toolTip">
+          <string>Open a typhos screen for the spectrometer</string>
+         </property>
+         <property name="text">
+          <string>spectrometer_name</string>
+         </property>
+        </widget>
+       </item>
+       <item row="20" column="0">
+        <widget class="QLabel" name="grid_points_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Number of grid points in frequency and time axes.
+</string>
+         </property>
+         <property name="text">
+          <string>Grid points</string>
+         </property>
+         <property name="buddy">
+          <cstring>num_grid_points_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="27" column="1" colspan="2">
         <widget class="SolverComboBox" name="solver_combo">
          <property name="toolTip">
           <string>Retriever solver to use</string>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="2">
+        <widget class="QPushButton" name="scan_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Scan the stage with the above parameters</string>
+         </property>
+         <property name="text">
+          <string>&amp;Start scan</string>
+         </property>
+        </widget>
+       </item>
+       <item row="31" column="1" colspan="2">
+        <widget class="QSpinBox" name="oversampling_spinbox">
+         <property name="minimum">
+          <number>0</number>
+         </property>
+         <property name="maximum">
+          <number>10000</number>
+         </property>
+         <property name="value">
+          <number>8</number>
+         </property>
+        </widget>
+       </item>
+       <item row="34" column="0">
+        <widget class="QLabel" name="debug_mode_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Phase blanking threshold</string>
+         </property>
+         <property name="text">
+          <string>Debug mode</string>
+         </property>
+         <property name="buddy">
+          <cstring>debug_mode_checkbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="15" column="0" colspan="3">
+        <widget class="QLabel" name="scan_status_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Scan: not in progress</string>
          </property>
         </widget>
        </item>
@@ -91,16 +219,116 @@
          </property>
         </widget>
        </item>
-       <item row="12" column="0" colspan="3">
-        <widget class="QProgressBar" name="scan_progress">
-         <property name="value">
-          <number>24</number>
+       <item row="2" column="0">
+        <widget class="QLabel" name="spectrometer_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
-         <property name="textVisible">
+         <property name="text">
+          <string>Spectrometer</string>
+         </property>
+         <property name="buddy">
+          <cstring>spectrometer_suite_button</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="32" column="1">
+        <widget class="QCheckBox" name="phase_blanking_checkbox">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checked">
           <bool>true</bool>
          </property>
-         <property name="invertedAppearance">
-          <bool>false</bool>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="TyphosRelatedSuiteButton" name="stage_suite_button">
+         <property name="toolTip">
+          <string>Open a typhos screen for the stage</string>
+         </property>
+         <property name="text">
+          <string>stage_name</string>
+         </property>
+        </widget>
+       </item>
+       <item row="22" column="0">
+        <widget class="QLabel" name="fundamental_range_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Fundamental spectrum window</string>
+         </property>
+         <property name="text">
+          <string>Fundamental range</string>
+         </property>
+         <property name="buddy">
+          <cstring>fundamental_low_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="27" column="0">
+        <widget class="QLabel" name="solver_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>The retriever solver to use. </string>
+         </property>
+         <property name="text">
+          <string>Solver</string>
+         </property>
+         <property name="buddy">
+          <cstring>solver_combo</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="30" column="1">
+        <widget class="QCheckBox" name="apply_limit_checkbox">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="35" column="0">
+        <widget class="QPushButton" name="replot_button">
+         <property name="toolTip">
+          <string>Update plots with the above parameters</string>
+         </property>
+         <property name="text">
+          <string>Replot</string>
+         </property>
+        </widget>
+       </item>
+       <item row="22" column="2">
+        <widget class="QDoubleSpinBox" name="fundamental_high_spinbox">
+         <property name="suffix">
+          <string> nm</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>1000000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>900.000000000000000</double>
          </property>
         </widget>
        </item>
@@ -126,17 +354,7 @@
          </property>
         </widget>
        </item>
-       <item row="30" column="1">
-        <widget class="QCheckBox" name="phase_blanking_checkbox">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="21" column="0">
+       <item row="23" column="0">
         <widget class="QLabel" name="center_banwidth_label">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -152,793 +370,6 @@
          </property>
          <property name="buddy">
           <cstring>freq_bandwidth_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="0">
-        <widget class="QLabel" name="dwell_time_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Dwell time</string>
-         </property>
-         <property name="buddy">
-          <cstring>scan_wavelength_low_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="stage_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Stage</string>
-         </property>
-         <property name="buddy">
-          <cstring>stage_suite_button</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="32" column="0">
-        <widget class="QLabel" name="debug_mode_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Phase blanking threshold</string>
-         </property>
-         <property name="text">
-          <string>Debug mode</string>
-         </property>
-         <property name="buddy">
-          <cstring>debug_mode_checkbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="25" column="0">
-        <widget class="QLabel" name="solver_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>The retriever solver to use. </string>
-         </property>
-         <property name="text">
-          <string>Solver</string>
-         </property>
-         <property name="buddy">
-          <cstring>solver_combo</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="31" column="1" colspan="2">
-        <widget class="QDoubleSpinBox" name="phase_blanking_threshold_spinbox">
-         <property name="suffix">
-          <string/>
-         </property>
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>0.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>100000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>0.010000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="scan_wavelength_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Wavelengths</string>
-         </property>
-         <property name="buddy">
-          <cstring>scan_wavelength_low_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="16" column="0">
-        <widget class="QLabel" name="wedge_angle_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>The wedge angle (for traditional d-scan, not grating)
-</string>
-         </property>
-         <property name="text">
-          <string>Wedge angle</string>
-         </property>
-         <property name="buddy">
-          <cstring>wedge_angle_spin</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="26" column="2">
-        <widget class="QPushButton" name="export_button">
-         <property name="toolTip">
-          <string>Export data to a file (or .dat files)</string>
-         </property>
-         <property name="text">
-          <string>Export</string>
-         </property>
-        </widget>
-       </item>
-       <item row="24" column="1" colspan="2">
-        <widget class="PulseAnalysisComboBox" name="pulse_analysis_combo">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="QSpinBox" name="scan_steps_spinbox">
-         <property name="toolTip">
-          <string>Number of steps over the scan range (calculated by np.linspace)</string>
-         </property>
-         <property name="minimum">
-          <number>5</number>
-         </property>
-         <property name="maximum">
-          <number>10000</number>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="1">
-        <widget class="QSpinBox" name="spectra_per_step_spinbox">
-         <property name="toolTip">
-          <string>Each step, take this number of spectra and use the average</string>
-         </property>
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>100</number>
-         </property>
-         <property name="value">
-          <number>1</number>
-         </property>
-        </widget>
-       </item>
-       <item row="22" column="0">
-        <widget class="QLabel" name="material_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>The material used in the d-scan.
-</string>
-         </property>
-         <property name="text">
-          <string>Material</string>
-         </property>
-         <property name="buddy">
-          <cstring>material_combo</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="23" column="0">
-        <widget class="QLabel" name="nonlinear_process_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>The non-linear process to use
-</string>
-         </property>
-         <property name="text">
-          <string>Non-linear process</string>
-         </property>
-         <property name="buddy">
-          <cstring>nonlinear_combo</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="17" column="1" colspan="2">
-        <widget class="QSpinBox" name="blur_sigma_spinbox">
-         <property name="suffix">
-          <string> stdev</string>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="1">
-        <widget class="QDoubleSpinBox" name="dwell_time_spinbox">
-         <property name="toolTip">
-          <string>Wait this amount of time at each scan point before acquiring data from the spectrometer</string>
-         </property>
-         <property name="suffix">
-          <string> sec</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>0.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>1000000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>0.100000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="19" column="0">
-        <widget class="QLabel" name="iterations_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Maximum number of iterations for the retriever</string>
-         </property>
-         <property name="text">
-          <string>Iterations</string>
-         </property>
-         <property name="buddy">
-          <cstring>iterations_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="scan_steps_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Scan steps</string>
-         </property>
-         <property name="buddy">
-          <cstring>scan_steps_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="32" column="1">
-        <widget class="QCheckBox" name="debug_mode_checkbox">
-         <property name="toolTip">
-          <string>Show all available debug plots in separate windows after pulse retrieval</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="2">
-        <widget class="PyDMLabel" name="stage_status_label">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="precision" stdset="0">
-          <number>3</number>
-         </property>
-         <property name="showUnits" stdset="0">
-          <bool>true</bool>
-         </property>
-         <property name="precisionFromPV" stdset="0">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="18" column="0">
-        <widget class="QLabel" name="grid_points_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Number of grid points in frequency and time axes.
-</string>
-         </property>
-         <property name="text">
-          <string>Grid points</string>
-         </property>
-         <property name="buddy">
-          <cstring>num_grid_points_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="20" column="2">
-        <widget class="QDoubleSpinBox" name="fundamental_high_spinbox">
-         <property name="suffix">
-          <string> nm</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>0.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>1000000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>900.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="18" column="1" colspan="2">
-        <widget class="QSpinBox" name="num_grid_points_spinbox">
-         <property name="minimum">
-          <number>10</number>
-         </property>
-         <property name="maximum">
-          <number>100000</number>
-         </property>
-         <property name="value">
-          <number>3000</number>
-         </property>
-        </widget>
-       </item>
-       <item row="20" column="1">
-        <widget class="QDoubleSpinBox" name="fundamental_low_spinbox">
-         <property name="suffix">
-          <string> nm</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>0.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>100000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>700.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="29" column="0">
-        <widget class="QLabel" name="oversampling_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Oversampling</string>
-         </property>
-         <property name="text">
-          <string>Oversampling</string>
-         </property>
-         <property name="buddy">
-          <cstring>oversampling_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="2">
-        <widget class="PyDMLabel" name="spectrometer_status_label">
-         <property name="toolTip">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="1">
-        <widget class="QPushButton" name="take_fundamental_button">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Take a new fundamental spectrum, overriding the previous.  Defaults to the middle scan point if not separately acquired.</string>
-         </property>
-         <property name="text">
-          <string>Take fundamental</string>
-         </property>
-        </widget>
-       </item>
-       <item row="27" column="1">
-        <widget class="QLabel" name="plot_settings_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Plot settings</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="13" column="0" colspan="3">
-        <widget class="QLabel" name="scan_status_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Scan: not in progress</string>
-         </property>
-        </widget>
-       </item>
-       <item row="24" column="0">
-        <widget class="QLabel" name="pulse_analysis_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>The pulse analysis method to use
-</string>
-         </property>
-         <property name="text">
-          <string>Pulse analysis</string>
-         </property>
-         <property name="buddy">
-          <cstring>pulse_analysis_combo</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="17" column="0">
-        <widget class="QLabel" name="blur_sigma_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Strength of Gaussian blur applied to raw data (standard deviations).
-</string>
-         </property>
-         <property name="text">
-          <string>Blur sigma</string>
-         </property>
-         <property name="buddy">
-          <cstring>blur_sigma_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="2">
-        <widget class="QPushButton" name="scan_button">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Scan the stage with the above parameters</string>
-         </property>
-         <property name="text">
-          <string>&amp;Start scan</string>
-         </property>
-        </widget>
-       </item>
-       <item row="29" column="1" colspan="2">
-        <widget class="QSpinBox" name="oversampling_spinbox">
-         <property name="minimum">
-          <number>0</number>
-         </property>
-         <property name="maximum">
-          <number>10000</number>
-         </property>
-         <property name="value">
-          <number>8</number>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="0">
-        <widget class="QCheckBox" name="save_automatically_checkbox">
-         <property name="toolTip">
-          <string>Save scan data automatically (in npz format) to the specified directory</string>
-         </property>
-         <property name="text">
-          <string>Auto save</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="per_step_spectra_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Per-step spectra</string>
-         </property>
-         <property name="buddy">
-          <cstring>scan_steps_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="19" column="1" colspan="2">
-        <widget class="QSpinBox" name="iterations_spinbox">
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>10000</number>
-         </property>
-         <property name="value">
-          <number>30</number>
-         </property>
-        </widget>
-       </item>
-       <item row="30" column="0">
-        <widget class="QLabel" name="phase_blanking_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Enable phase blanking with pypret masking</string>
-         </property>
-         <property name="text">
-          <string>Phase blanking</string>
-         </property>
-         <property name="buddy">
-          <cstring>phase_blanking_checkbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="31" column="0">
-        <widget class="QLabel" name="phase_blanking_threshold_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Phase blanking threshold</string>
-         </property>
-         <property name="text">
-          <string>Threshold</string>
-         </property>
-         <property name="buddy">
-          <cstring>phase_blanking_threshold_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="23" column="1" colspan="2">
-        <widget class="NonlinearComboBox" name="nonlinear_combo"/>
-       </item>
-       <item row="28" column="0">
-        <widget class="QLabel" name="apply_limit_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Determine and apply a limit using pypret.
-</string>
-         </property>
-         <property name="text">
-          <string>Apply limit</string>
-         </property>
-         <property name="buddy">
-          <cstring>apply_limit_checkbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="21" column="1" colspan="2">
-        <widget class="QDoubleSpinBox" name="freq_bandwidth_spinbox">
-         <property name="suffix">
-          <string> nm</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>0.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>100000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>800.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="28" column="1">
-        <widget class="QCheckBox" name="apply_limit_checkbox">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="spectrometer_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Spectrometer</string>
-         </property>
-         <property name="buddy">
-          <cstring>spectrometer_suite_button</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="15" column="0" colspan="3">
-        <widget class="QLabel" name="retriever_settings_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Retriever settings</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QDoubleSpinBox" name="scan_wavelength_low_spinbox">
-         <property name="toolTip">
-          <string>Lower scan wavelength</string>
-         </property>
-         <property name="suffix">
-          <string> nm</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>0.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>1000000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>350.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="26" column="1">
-        <widget class="QPushButton" name="import_button">
-         <property name="toolTip">
-          <string>Import data from previous scans</string>
-         </property>
-         <property name="text">
-          <string>Import</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="2">
-        <widget class="QDoubleSpinBox" name="scan_wavelength_high_spinbox">
-         <property name="toolTip">
-          <string>Upper scan wavelength</string>
-         </property>
-         <property name="suffix">
-          <string> nm</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>0.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>100000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>450.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="TyphosRelatedSuiteButton" name="stage_suite_button">
-         <property name="toolTip">
-          <string>Open a typhos screen for the stage</string>
-         </property>
-         <property name="text">
-          <string>stage_name</string>
-         </property>
-        </widget>
-       </item>
-       <item row="22" column="1" colspan="2">
-        <widget class="MaterialComboBox" name="material_combo"/>
-       </item>
-       <item row="34" column="1">
-        <spacer name="left_spacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="16" column="1" colspan="2">
-        <widget class="QDoubleSpinBox" name="wedge_angle_spin">
-         <property name="suffix">
-          <string> deg</string>
-         </property>
-         <property name="decimals">
-          <number>5</number>
-         </property>
-         <property name="minimum">
-          <double>-360.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>360.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>8.000000000000000</double>
          </property>
         </widget>
        </item>
@@ -964,17 +395,103 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
-        <widget class="TyphosRelatedSuiteButton" name="spectrometer_suite_button">
+       <item row="4" column="2">
+        <widget class="QDoubleSpinBox" name="scan_wavelength_high_spinbox">
          <property name="toolTip">
-          <string>Open a typhos screen for the spectrometer</string>
+          <string>Upper scan wavelength</string>
          </property>
-         <property name="text">
-          <string>spectrometer_name</string>
+         <property name="suffix">
+          <string> nm</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>100000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>450.000000000000000</double>
          </property>
         </widget>
        </item>
-       <item row="33" column="2">
+       <item row="24" column="0">
+        <widget class="QLabel" name="material_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>The material used in the d-scan.
+</string>
+         </property>
+         <property name="text">
+          <string>Material</string>
+         </property>
+         <property name="buddy">
+          <cstring>material_combo</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="18" column="1" colspan="2">
+        <widget class="QDoubleSpinBox" name="wedge_angle_spin">
+         <property name="suffix">
+          <string> deg</string>
+         </property>
+         <property name="decimals">
+          <number>5</number>
+         </property>
+         <property name="minimum">
+          <double>-360.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>360.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>8.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="PyDMLabel" name="stage_status_label">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="precision" stdset="0">
+          <number>3</number>
+         </property>
+         <property name="showUnits" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="precisionFromPV" stdset="0">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="33" column="1" colspan="2">
+        <widget class="QDoubleSpinBox" name="phase_blanking_threshold_spinbox">
+         <property name="suffix">
+          <string/>
+         </property>
+         <property name="decimals">
+          <number>6</number>
+         </property>
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>100000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>0.010000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="35" column="2">
         <widget class="QPushButton" name="save_plots_button">
          <property name="toolTip">
           <string>Save plots to image files</string>
@@ -984,7 +501,110 @@
          </property>
         </widget>
        </item>
-       <item row="26" column="0">
+       <item row="26" column="1" colspan="2">
+        <widget class="PulseAnalysisComboBox" name="pulse_analysis_combo">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="36" column="1">
+        <spacer name="left_spacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="25" column="0">
+        <widget class="QLabel" name="nonlinear_process_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>The non-linear process to use
+</string>
+         </property>
+         <property name="text">
+          <string>Non-linear process</string>
+         </property>
+         <property name="buddy">
+          <cstring>nonlinear_combo</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="22" column="1">
+        <widget class="QDoubleSpinBox" name="fundamental_low_spinbox">
+         <property name="suffix">
+          <string> nm</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>100000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>700.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <widget class="QDoubleSpinBox" name="dwell_time_spinbox">
+         <property name="toolTip">
+          <string>Wait this amount of time at each scan point before acquiring data from the spectrometer</string>
+         </property>
+         <property name="suffix">
+          <string> sec</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>1000000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>0.100000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QDoubleSpinBox" name="scan_wavelength_low_spinbox">
+         <property name="toolTip">
+          <string>Lower scan wavelength</string>
+         </property>
+         <property name="suffix">
+          <string> nm</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>1000000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>350.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="28" column="0">
         <widget class="QPushButton" name="update_button">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -1000,13 +620,438 @@
          </property>
         </widget>
        </item>
-       <item row="33" column="0">
-        <widget class="QPushButton" name="replot_button">
-         <property name="toolTip">
-          <string>Update plots with the above parameters</string>
+       <item row="29" column="1">
+        <widget class="QLabel" name="plot_settings_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
          </property>
          <property name="text">
-          <string>Replot</string>
+          <string>Plot settings</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="QSpinBox" name="spectra_per_step_spinbox">
+         <property name="toolTip">
+          <string>Each step, take this number of spectra and use the average</string>
+         </property>
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>100</number>
+         </property>
+         <property name="value">
+          <number>1</number>
+         </property>
+        </widget>
+       </item>
+       <item row="33" column="0">
+        <widget class="QLabel" name="phase_blanking_threshold_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Phase blanking threshold</string>
+         </property>
+         <property name="text">
+          <string>Threshold</string>
+         </property>
+         <property name="buddy">
+          <cstring>phase_blanking_threshold_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="19" column="0">
+        <widget class="QLabel" name="blur_sigma_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Strength of Gaussian blur applied to raw data (standard deviations).
+</string>
+         </property>
+         <property name="text">
+          <string>Blur sigma</string>
+         </property>
+         <property name="buddy">
+          <cstring>blur_sigma_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="1">
+        <widget class="QPushButton" name="take_fundamental_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Take a new fundamental spectrum, overriding the previous.  Defaults to the middle scan point if not separately acquired.</string>
+         </property>
+         <property name="text">
+          <string>Take fundamental</string>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="0" colspan="3">
+        <widget class="QProgressBar" name="scan_progress">
+         <property name="value">
+          <number>24</number>
+         </property>
+         <property name="textVisible">
+          <bool>true</bool>
+         </property>
+         <property name="invertedAppearance">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="28" column="2">
+        <widget class="QPushButton" name="export_button">
+         <property name="toolTip">
+          <string>Export data to a file (or .dat files)</string>
+         </property>
+         <property name="text">
+          <string>Export</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="scan_steps_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Scan steps</string>
+         </property>
+         <property name="buddy">
+          <cstring>scan_steps_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="17" column="0" colspan="3">
+        <widget class="QLabel" name="retriever_settings_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Retriever settings</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="24" column="1" colspan="2">
+        <widget class="MaterialComboBox" name="material_combo"/>
+       </item>
+       <item row="8" column="0">
+        <widget class="QLabel" name="dwell_time_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Dwell time</string>
+         </property>
+         <property name="buddy">
+          <cstring>scan_wavelength_low_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="per_step_spectra_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Per-step spectra</string>
+         </property>
+         <property name="buddy">
+          <cstring>scan_steps_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="20" column="1" colspan="2">
+        <widget class="QSpinBox" name="num_grid_points_spinbox">
+         <property name="minimum">
+          <number>10</number>
+         </property>
+         <property name="maximum">
+          <number>100000</number>
+         </property>
+         <property name="value">
+          <number>3000</number>
+         </property>
+        </widget>
+       </item>
+       <item row="26" column="0">
+        <widget class="QLabel" name="pulse_analysis_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>The pulse analysis method to use
+</string>
+         </property>
+         <property name="text">
+          <string>Pulse analysis</string>
+         </property>
+         <property name="buddy">
+          <cstring>pulse_analysis_combo</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="18" column="0">
+        <widget class="QLabel" name="wedge_angle_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>The wedge angle (for traditional d-scan, not grating)
+</string>
+         </property>
+         <property name="text">
+          <string>Wedge angle</string>
+         </property>
+         <property name="buddy">
+          <cstring>wedge_angle_spin</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QSpinBox" name="scan_steps_spinbox">
+         <property name="toolTip">
+          <string>Number of steps over the scan range (calculated by np.linspace)</string>
+         </property>
+         <property name="minimum">
+          <number>5</number>
+         </property>
+         <property name="maximum">
+          <number>10000</number>
+         </property>
+        </widget>
+       </item>
+       <item row="32" column="0">
+        <widget class="QLabel" name="phase_blanking_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Enable phase blanking with pypret masking</string>
+         </property>
+         <property name="text">
+          <string>Phase blanking</string>
+         </property>
+         <property name="buddy">
+          <cstring>phase_blanking_checkbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="31" column="0">
+        <widget class="QLabel" name="oversampling_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Oversampling</string>
+         </property>
+         <property name="text">
+          <string>Oversampling</string>
+         </property>
+         <property name="buddy">
+          <cstring>oversampling_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="start_pos_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Scan range</string>
+         </property>
+         <property name="buddy">
+          <cstring>scan_start_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="23" column="1" colspan="2">
+        <widget class="QDoubleSpinBox" name="freq_bandwidth_spinbox">
+         <property name="suffix">
+          <string> nm</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>100000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>800.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="21" column="0">
+        <widget class="QLabel" name="iterations_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Maximum number of iterations for the retriever</string>
+         </property>
+         <property name="text">
+          <string>Iterations</string>
+         </property>
+         <property name="buddy">
+          <cstring>iterations_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="30" column="0">
+        <widget class="QLabel" name="apply_limit_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Determine and apply a limit using pypret.
+</string>
+         </property>
+         <property name="text">
+          <string>Apply limit</string>
+         </property>
+         <property name="buddy">
+          <cstring>apply_limit_checkbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="21" column="1" colspan="2">
+        <widget class="QSpinBox" name="iterations_spinbox">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>10000</number>
+         </property>
+         <property name="value">
+          <number>30</number>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="0">
+        <widget class="QLabel" name="auto_fundamental_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Set fundamental</string>
+         </property>
+         <property name="buddy">
+          <cstring>scan_wavelength_low_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="0">
+        <widget class="QLabel" name="save_automatically_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Auto save</string>
+         </property>
+         <property name="buddy">
+          <cstring>scan_wavelength_low_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="1" colspan="2">
+        <widget class="QCheckBox" name="auto_fundamental_checkbox">
+         <property name="toolTip">
+          <string>Automatically use center of scan range for fundamental spectrum</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="1" colspan="2">
+        <widget class="QCheckBox" name="save_automatically_checkbox">
+         <property name="toolTip">
+          <string>Save scan data automatically (in npz format) to the specified directory</string>
+         </property>
+         <property name="text">
+          <string/>
          </property>
         </widget>
        </item>
@@ -1286,7 +1331,6 @@
   <tabstop>scan_steps_spinbox</tabstop>
   <tabstop>spectra_per_step_spinbox</tabstop>
   <tabstop>dwell_time_spinbox</tabstop>
-  <tabstop>save_automatically_checkbox</tabstop>
   <tabstop>take_fundamental_button</tabstop>
   <tabstop>scan_button</tabstop>
   <tabstop>wedge_angle_spin</tabstop>

--- a/las_dispersion_scan/ui/main.ui
+++ b/las_dispersion_scan/ui/main.ui
@@ -63,7 +63,11 @@
         </widget>
        </item>
        <item row="25" column="1" colspan="2">
-        <widget class="SolverComboBox" name="solver_combo"/>
+        <widget class="SolverComboBox" name="solver_combo">
+         <property name="toolTip">
+          <string>Retriever solver to use</string>
+         </property>
+        </widget>
        </item>
        <item row="0" column="0" colspan="3">
         <widget class="QLabel" name="params_label">
@@ -102,6 +106,9 @@
        </item>
        <item row="3" column="1">
         <widget class="QDoubleSpinBox" name="scan_start_spinbox">
+         <property name="toolTip">
+          <string>Starting stage (motor) position</string>
+         </property>
          <property name="suffix">
           <string> mm</string>
          </property>
@@ -276,7 +283,7 @@
        <item row="26" column="2">
         <widget class="QPushButton" name="export_button">
          <property name="toolTip">
-          <string>Export data to a file</string>
+          <string>Export data to a file (or .dat files)</string>
          </property>
          <property name="text">
           <string>Export</string>
@@ -292,6 +299,9 @@
        </item>
        <item row="5" column="1">
         <widget class="QSpinBox" name="scan_steps_spinbox">
+         <property name="toolTip">
+          <string>Number of steps over the scan range (calculated by np.linspace)</string>
+         </property>
          <property name="minimum">
           <number>5</number>
          </property>
@@ -302,6 +312,9 @@
        </item>
        <item row="6" column="1">
         <widget class="QSpinBox" name="spectra_per_step_spinbox">
+         <property name="toolTip">
+          <string>Each step, take this number of spectra and use the average</string>
+         </property>
          <property name="minimum">
           <number>1</number>
          </property>
@@ -362,6 +375,9 @@
        </item>
        <item row="8" column="1">
         <widget class="QDoubleSpinBox" name="dwell_time_spinbox">
+         <property name="toolTip">
+          <string>Wait this amount of time at each scan point before acquiring data from the spectrometer</string>
+         </property>
          <property name="suffix">
           <string> sec</string>
          </property>
@@ -548,6 +564,9 @@
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
+         <property name="toolTip">
+          <string>Take a new fundamental spectrum, overriding the previous.  Defaults to the middle scan point if not separately acquired.</string>
+         </property>
          <property name="text">
           <string>Take fundamental</string>
          </property>
@@ -635,6 +654,9 @@
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Scan the stage with the above parameters</string>
          </property>
          <property name="text">
           <string>&amp;Start scan</string>
@@ -823,6 +845,9 @@
        </item>
        <item row="4" column="1">
         <widget class="QDoubleSpinBox" name="scan_wavelength_low_spinbox">
+         <property name="toolTip">
+          <string>Lower scan wavelength</string>
+         </property>
          <property name="suffix">
           <string> nm</string>
          </property>
@@ -852,6 +877,9 @@
        </item>
        <item row="4" column="2">
         <widget class="QDoubleSpinBox" name="scan_wavelength_high_spinbox">
+         <property name="toolTip">
+          <string>Upper scan wavelength</string>
+         </property>
          <property name="suffix">
           <string> nm</string>
          </property>
@@ -872,7 +900,7 @@
        <item row="1" column="1">
         <widget class="TyphosRelatedSuiteButton" name="stage_suite_button">
          <property name="toolTip">
-          <string/>
+          <string>Open a typhos screen for the stage</string>
          </property>
          <property name="text">
           <string>stage_name</string>
@@ -916,6 +944,9 @@
        </item>
        <item row="3" column="2">
         <widget class="QDoubleSpinBox" name="scan_end_spinbox">
+         <property name="toolTip">
+          <string>Final, inclusive stage position</string>
+         </property>
          <property name="suffix">
           <string> mm</string>
          </property>
@@ -936,7 +967,7 @@
        <item row="2" column="1">
         <widget class="TyphosRelatedSuiteButton" name="spectrometer_suite_button">
          <property name="toolTip">
-          <string/>
+          <string>Open a typhos screen for the spectrometer</string>
          </property>
          <property name="text">
           <string>spectrometer_name</string>
@@ -946,7 +977,7 @@
        <item row="33" column="2">
         <widget class="QPushButton" name="save_plots_button">
          <property name="toolTip">
-          <string>Export data to a file</string>
+          <string>Save plots to image files</string>
          </property>
          <property name="text">
           <string>Save plots</string>
@@ -972,7 +1003,7 @@
        <item row="33" column="0">
         <widget class="QPushButton" name="replot_button">
          <property name="toolTip">
-          <string>Export data to a file</string>
+          <string>Update plots with the above parameters</string>
          </property>
          <property name="text">
           <string>Replot</string>

--- a/las_dispersion_scan/ui/main.ui
+++ b/las_dispersion_scan/ui/main.ui
@@ -27,85 +27,87 @@
        </size>
       </property>
       <layout class="QGridLayout" name="plot_grid_layout">
-       <item row="34" column="1">
-        <widget class="QCheckBox" name="debug_mode_checkbox">
-         <property name="toolTip">
-          <string>Show all available debug plots in separate windows after pulse retrieval</string>
+       <item row="25" column="1">
+        <widget class="NonlinearComboBox" name="nonlinear_combo"/>
+       </item>
+       <item row="8" column="0">
+        <widget class="QLabel" name="dwell_time_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
+         <property name="text">
+          <string>&amp;Dwell time</string>
+         </property>
+         <property name="buddy">
+          <cstring>dwell_time_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="33" column="1" colspan="2">
+        <widget class="QSpinBox" name="oversampling_spinbox">
+         <property name="minimum">
+          <number>0</number>
+         </property>
+         <property name="maximum">
+          <number>10000</number>
+         </property>
+         <property name="value">
+          <number>8</number>
+         </property>
+        </widget>
+       </item>
+       <item row="24" column="1">
+        <widget class="MaterialComboBox" name="material_combo"/>
+       </item>
+       <item row="26" column="0">
+        <widget class="QLabel" name="pulse_analysis_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>The pulse analysis method to use
+</string>
+         </property>
+         <property name="text">
+          <string>Pulse analysis</string>
+         </property>
+         <property name="buddy">
+          <cstring>pulse_analysis_combo</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="33" column="0">
+        <widget class="QLabel" name="oversampling_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Oversampling</string>
+         </property>
+         <property name="text">
+          <string>Oversampling</string>
+         </property>
+         <property name="buddy">
+          <cstring>oversampling_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="32" column="1">
+        <widget class="QCheckBox" name="apply_limit_checkbox">
          <property name="text">
           <string/>
          </property>
          <property name="checked">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="stage_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Stage</string>
-         </property>
-         <property name="buddy">
-          <cstring>stage_suite_button</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="2">
-        <widget class="PyDMLabel" name="spectrometer_status_label">
-         <property name="toolTip">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="28" column="1">
-        <widget class="QPushButton" name="import_button">
-         <property name="toolTip">
-          <string>Import data from previous scans</string>
-         </property>
-         <property name="text">
-          <string>Import</string>
-         </property>
-        </widget>
-       </item>
-       <item row="19" column="1" colspan="2">
-        <widget class="QSpinBox" name="blur_sigma_spinbox">
-         <property name="suffix">
-          <string> stdev</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="scan_wavelength_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Wavelengths</string>
-         </property>
-         <property name="buddy">
-          <cstring>scan_wavelength_low_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="25" column="1" colspan="2">
-        <widget class="NonlinearComboBox" name="nonlinear_combo"/>
-       </item>
-       <item row="2" column="1">
-        <widget class="TyphosRelatedSuiteButton" name="spectrometer_suite_button">
-         <property name="toolTip">
-          <string>Open a typhos screen for the spectrometer</string>
-         </property>
-         <property name="text">
-          <string>spectrometer_name</string>
+          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -126,629 +128,6 @@
          </property>
          <property name="buddy">
           <cstring>num_grid_points_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="27" column="1" colspan="2">
-        <widget class="SolverComboBox" name="solver_combo">
-         <property name="toolTip">
-          <string>Retriever solver to use</string>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="2">
-        <widget class="QPushButton" name="scan_button">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Scan the stage with the above parameters</string>
-         </property>
-         <property name="text">
-          <string>&amp;Start scan</string>
-         </property>
-        </widget>
-       </item>
-       <item row="31" column="1" colspan="2">
-        <widget class="QSpinBox" name="oversampling_spinbox">
-         <property name="minimum">
-          <number>0</number>
-         </property>
-         <property name="maximum">
-          <number>10000</number>
-         </property>
-         <property name="value">
-          <number>8</number>
-         </property>
-        </widget>
-       </item>
-       <item row="34" column="0">
-        <widget class="QLabel" name="debug_mode_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Phase blanking threshold</string>
-         </property>
-         <property name="text">
-          <string>Debug mode</string>
-         </property>
-         <property name="buddy">
-          <cstring>debug_mode_checkbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="15" column="0" colspan="3">
-        <widget class="QLabel" name="scan_status_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Scan: not in progress</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0" colspan="3">
-        <widget class="QLabel" name="params_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Scan parameters</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="spectrometer_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Spectrometer</string>
-         </property>
-         <property name="buddy">
-          <cstring>spectrometer_suite_button</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="32" column="1">
-        <widget class="QCheckBox" name="phase_blanking_checkbox">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="TyphosRelatedSuiteButton" name="stage_suite_button">
-         <property name="toolTip">
-          <string>Open a typhos screen for the stage</string>
-         </property>
-         <property name="text">
-          <string>stage_name</string>
-         </property>
-        </widget>
-       </item>
-       <item row="22" column="0">
-        <widget class="QLabel" name="fundamental_range_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Fundamental spectrum window</string>
-         </property>
-         <property name="text">
-          <string>Fundamental range</string>
-         </property>
-         <property name="buddy">
-          <cstring>fundamental_low_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="27" column="0">
-        <widget class="QLabel" name="solver_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>The retriever solver to use. </string>
-         </property>
-         <property name="text">
-          <string>Solver</string>
-         </property>
-         <property name="buddy">
-          <cstring>solver_combo</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="30" column="1">
-        <widget class="QCheckBox" name="apply_limit_checkbox">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="35" column="0">
-        <widget class="QPushButton" name="replot_button">
-         <property name="toolTip">
-          <string>Update plots with the above parameters</string>
-         </property>
-         <property name="text">
-          <string>Replot</string>
-         </property>
-        </widget>
-       </item>
-       <item row="22" column="2">
-        <widget class="QDoubleSpinBox" name="fundamental_high_spinbox">
-         <property name="suffix">
-          <string> nm</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>0.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>1000000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>900.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
-        <widget class="QDoubleSpinBox" name="scan_start_spinbox">
-         <property name="toolTip">
-          <string>Starting stage (motor) position</string>
-         </property>
-         <property name="suffix">
-          <string> mm</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>-10000000000.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>10000000000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>23.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="23" column="0">
-        <widget class="QLabel" name="center_banwidth_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Bandwidth around center wavelength for frequency and time axes (nm)</string>
-         </property>
-         <property name="text">
-          <string>Center bandwidth</string>
-         </property>
-         <property name="buddy">
-          <cstring>freq_bandwidth_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="2">
-        <widget class="QDoubleSpinBox" name="scan_end_spinbox">
-         <property name="toolTip">
-          <string>Final, inclusive stage position</string>
-         </property>
-         <property name="suffix">
-          <string> mm</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>-10000000000.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>10000000000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>25.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="2">
-        <widget class="QDoubleSpinBox" name="scan_wavelength_high_spinbox">
-         <property name="toolTip">
-          <string>Upper scan wavelength</string>
-         </property>
-         <property name="suffix">
-          <string> nm</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>0.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>100000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>450.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="24" column="0">
-        <widget class="QLabel" name="material_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>The material used in the d-scan.
-</string>
-         </property>
-         <property name="text">
-          <string>Material</string>
-         </property>
-         <property name="buddy">
-          <cstring>material_combo</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="18" column="1" colspan="2">
-        <widget class="QDoubleSpinBox" name="wedge_angle_spin">
-         <property name="suffix">
-          <string> deg</string>
-         </property>
-         <property name="decimals">
-          <number>5</number>
-         </property>
-         <property name="minimum">
-          <double>-360.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>360.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>8.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="2">
-        <widget class="PyDMLabel" name="stage_status_label">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="precision" stdset="0">
-          <number>3</number>
-         </property>
-         <property name="showUnits" stdset="0">
-          <bool>true</bool>
-         </property>
-         <property name="precisionFromPV" stdset="0">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="33" column="1" colspan="2">
-        <widget class="QDoubleSpinBox" name="phase_blanking_threshold_spinbox">
-         <property name="suffix">
-          <string/>
-         </property>
-         <property name="decimals">
-          <number>6</number>
-         </property>
-         <property name="minimum">
-          <double>0.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>100000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>0.010000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="35" column="2">
-        <widget class="QPushButton" name="save_plots_button">
-         <property name="toolTip">
-          <string>Save plots to image files</string>
-         </property>
-         <property name="text">
-          <string>Save plots</string>
-         </property>
-        </widget>
-       </item>
-       <item row="26" column="1" colspan="2">
-        <widget class="PulseAnalysisComboBox" name="pulse_analysis_combo">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="36" column="1">
-        <spacer name="left_spacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="25" column="0">
-        <widget class="QLabel" name="nonlinear_process_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>The non-linear process to use
-</string>
-         </property>
-         <property name="text">
-          <string>Non-linear process</string>
-         </property>
-         <property name="buddy">
-          <cstring>nonlinear_combo</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="22" column="1">
-        <widget class="QDoubleSpinBox" name="fundamental_low_spinbox">
-         <property name="suffix">
-          <string> nm</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>0.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>100000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>700.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="1">
-        <widget class="QDoubleSpinBox" name="dwell_time_spinbox">
-         <property name="toolTip">
-          <string>Wait this amount of time at each scan point before acquiring data from the spectrometer</string>
-         </property>
-         <property name="suffix">
-          <string> sec</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>0.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>1000000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>0.100000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QDoubleSpinBox" name="scan_wavelength_low_spinbox">
-         <property name="toolTip">
-          <string>Lower scan wavelength</string>
-         </property>
-         <property name="suffix">
-          <string> nm</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>0.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>1000000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>350.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="28" column="0">
-        <widget class="QPushButton" name="update_button">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Recalculate using the current retriever settings</string>
-         </property>
-         <property name="text">
-          <string>Recalculate</string>
-         </property>
-        </widget>
-       </item>
-       <item row="29" column="1">
-        <widget class="QLabel" name="plot_settings_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Plot settings</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="1">
-        <widget class="QSpinBox" name="spectra_per_step_spinbox">
-         <property name="toolTip">
-          <string>Each step, take this number of spectra and use the average</string>
-         </property>
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>100</number>
-         </property>
-         <property name="value">
-          <number>1</number>
-         </property>
-        </widget>
-       </item>
-       <item row="33" column="0">
-        <widget class="QLabel" name="phase_blanking_threshold_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Phase blanking threshold</string>
-         </property>
-         <property name="text">
-          <string>Threshold</string>
-         </property>
-         <property name="buddy">
-          <cstring>phase_blanking_threshold_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="19" column="0">
-        <widget class="QLabel" name="blur_sigma_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Strength of Gaussian blur applied to raw data (standard deviations).
-</string>
-         </property>
-         <property name="text">
-          <string>Blur sigma</string>
-         </property>
-         <property name="buddy">
-          <cstring>blur_sigma_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="1">
-        <widget class="QPushButton" name="take_fundamental_button">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Take a new fundamental spectrum, overriding the previous.  Defaults to the middle scan point if not separately acquired.</string>
-         </property>
-         <property name="text">
-          <string>Take fundamental</string>
-         </property>
-        </widget>
-       </item>
-       <item row="14" column="0" colspan="3">
-        <widget class="QProgressBar" name="scan_progress">
-         <property name="value">
-          <number>24</number>
-         </property>
-         <property name="textVisible">
-          <bool>true</bool>
-         </property>
-         <property name="invertedAppearance">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="28" column="2">
-        <widget class="QPushButton" name="export_button">
-         <property name="toolTip">
-          <string>Export data to a file (or .dat files)</string>
-         </property>
-         <property name="text">
-          <string>Export</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="scan_steps_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Scan steps</string>
-         </property>
-         <property name="buddy">
-          <cstring>scan_steps_spinbox</cstring>
          </property>
         </widget>
        </item>
@@ -774,11 +153,237 @@
          </property>
         </widget>
        </item>
-       <item row="24" column="1" colspan="2">
-        <widget class="MaterialComboBox" name="material_combo"/>
+       <item row="39" column="1">
+        <spacer name="left_spacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
-       <item row="8" column="0">
-        <widget class="QLabel" name="dwell_time_label">
+       <item row="38" column="0">
+        <widget class="QPushButton" name="replot_button">
+         <property name="toolTip">
+          <string>Update plots with the above parameters</string>
+         </property>
+         <property name="text">
+          <string>Replot</string>
+         </property>
+        </widget>
+       </item>
+       <item row="35" column="1">
+        <widget class="QDoubleSpinBox" name="phase_blanking_threshold_spinbox">
+         <property name="suffix">
+          <string/>
+         </property>
+         <property name="decimals">
+          <number>6</number>
+         </property>
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>100000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>0.010000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0" colspan="3">
+        <widget class="QLabel" name="params_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Scan parameters</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="0" colspan="3">
+        <widget class="QProgressBar" name="scan_progress">
+         <property name="value">
+          <number>24</number>
+         </property>
+         <property name="textVisible">
+          <bool>true</bool>
+         </property>
+         <property name="invertedAppearance">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="37" column="1">
+        <widget class="QCheckBox" name="debug_mode_checkbox">
+         <property name="toolTip">
+          <string>Show all available debug plots in separate windows after pulse retrieval</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="34" column="0">
+        <widget class="QLabel" name="phase_blanking_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Enable phase blanking with pypret masking</string>
+         </property>
+         <property name="text">
+          <string>Phase blanking</string>
+         </property>
+         <property name="buddy">
+          <cstring>phase_blanking_checkbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="29" column="1">
+        <widget class="QDoubleSpinBox" name="plot_position_spinbox">
+         <property name="toolTip">
+          <string>After retrieval, plot at this position</string>
+         </property>
+         <property name="suffix">
+          <string> mm</string>
+         </property>
+         <property name="decimals">
+          <number>6</number>
+         </property>
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>100000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>0.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QDoubleSpinBox" name="scan_start_spinbox">
+         <property name="toolTip">
+          <string>Starting stage (motor) position</string>
+         </property>
+         <property name="suffix">
+          <string> mm</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>-10000000000.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>10000000000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>23.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <widget class="QDoubleSpinBox" name="dwell_time_spinbox">
+         <property name="toolTip">
+          <string>Wait this amount of time at each scan point before acquiring data from the spectrometer</string>
+         </property>
+         <property name="suffix">
+          <string> sec</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>1000000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>0.100000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="1" colspan="2">
+        <widget class="QCheckBox" name="auto_fundamental_checkbox">
+         <property name="toolTip">
+          <string>Automatically use center of scan range for fundamental spectrum</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QDoubleSpinBox" name="scan_wavelength_low_spinbox">
+         <property name="toolTip">
+          <string>Lower scan wavelength</string>
+         </property>
+         <property name="suffix">
+          <string> nm</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>1000000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>350.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="23" column="1">
+        <widget class="QDoubleSpinBox" name="freq_bandwidth_spinbox">
+         <property name="suffix">
+          <string> nm</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>100000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>800.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="0">
+        <widget class="QLabel" name="save_automatically_label">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -786,30 +391,69 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>Dwell time</string>
+          <string>&amp;Auto save</string>
+         </property>
+         <property name="buddy">
+          <cstring>save_automatically_checkbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="38" column="2">
+        <widget class="QPushButton" name="save_plots_button">
+         <property name="toolTip">
+          <string>Save plots to image files</string>
+         </property>
+         <property name="text">
+          <string>Save plots</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="scan_wavelength_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>&amp;Wavelengths</string>
          </property>
          <property name="buddy">
           <cstring>scan_wavelength_low_spinbox</cstring>
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="per_step_spectra_label">
+       <item row="23" column="0">
+        <widget class="QLabel" name="center_banwidth_label">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
+         <property name="toolTip">
+          <string>Bandwidth around center wavelength for frequency and time axes (nm)</string>
+         </property>
          <property name="text">
-          <string>Per-step spectra</string>
+          <string>&amp;Center bandwidth</string>
          </property>
          <property name="buddy">
-          <cstring>scan_steps_spinbox</cstring>
+          <cstring>freq_bandwidth_spinbox</cstring>
          </property>
         </widget>
        </item>
-       <item row="20" column="1" colspan="2">
+       <item row="10" column="1" colspan="2">
+        <widget class="QCheckBox" name="save_automatically_checkbox">
+         <property name="toolTip">
+          <string>Save scan data automatically (in npz format) to the specified directory</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="20" column="1">
         <widget class="QSpinBox" name="num_grid_points_spinbox">
          <property name="minimum">
           <number>10</number>
@@ -822,8 +466,8 @@
          </property>
         </widget>
        </item>
-       <item row="26" column="0">
-        <widget class="QLabel" name="pulse_analysis_label">
+       <item row="21" column="0">
+        <widget class="QLabel" name="iterations_label">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -831,14 +475,491 @@
           </sizepolicy>
          </property>
          <property name="toolTip">
-          <string>The pulse analysis method to use
+          <string>Maximum number of iterations for the retriever</string>
+         </property>
+         <property name="text">
+          <string>Iterations</string>
+         </property>
+         <property name="buddy">
+          <cstring>iterations_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="PyDMLabel" name="stage_status_label">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="precision" stdset="0">
+          <number>3</number>
+         </property>
+         <property name="showUnits" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="precisionFromPV" stdset="0">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="PyDMLabel" name="spectrometer_status_label">
+         <property name="toolTip">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="21" column="1">
+        <widget class="QSpinBox" name="iterations_spinbox">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>10000</number>
+         </property>
+         <property name="value">
+          <number>30</number>
+         </property>
+        </widget>
+       </item>
+       <item row="19" column="1">
+        <widget class="QSpinBox" name="blur_sigma_spinbox">
+         <property name="suffix">
+          <string> stdev</string>
+         </property>
+        </widget>
+       </item>
+       <item row="27" column="0">
+        <widget class="QLabel" name="solver_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>The retriever solver to use. </string>
+         </property>
+         <property name="text">
+          <string>Solver</string>
+         </property>
+         <property name="buddy">
+          <cstring>solver_combo</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="1">
+        <widget class="QPushButton" name="take_fundamental_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Take a new fundamental spectrum, overriding the previous.  Defaults to the middle scan point if not separately acquired.</string>
+         </property>
+         <property name="text">
+          <string>Take &amp;fundamental</string>
+         </property>
+        </widget>
+       </item>
+       <item row="30" column="1">
+        <widget class="QPushButton" name="import_button">
+         <property name="toolTip">
+          <string>Import data from previous scans</string>
+         </property>
+         <property name="text">
+          <string>Import</string>
+         </property>
+        </widget>
+       </item>
+       <item row="26" column="1">
+        <widget class="PulseAnalysisComboBox" name="pulse_analysis_combo">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="QSpinBox" name="spectra_per_step_spinbox">
+         <property name="toolTip">
+          <string>Each step, take this number of spectra and use the average</string>
+         </property>
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>100</number>
+         </property>
+         <property name="value">
+          <number>1</number>
+         </property>
+        </widget>
+       </item>
+       <item row="24" column="0">
+        <widget class="QLabel" name="material_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>The material used in the d-scan.
 </string>
          </property>
          <property name="text">
-          <string>Pulse analysis</string>
+          <string>Material</string>
          </property>
          <property name="buddy">
-          <cstring>pulse_analysis_combo</cstring>
+          <cstring>material_combo</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="31" column="1">
+        <widget class="QLabel" name="plot_settings_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Plot settings</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="2">
+        <widget class="QDoubleSpinBox" name="scan_end_spinbox">
+         <property name="toolTip">
+          <string>Final, inclusive stage position</string>
+         </property>
+         <property name="suffix">
+          <string> mm</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>-10000000000.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>10000000000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>25.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="per_step_spectra_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>&amp;Per-step spectra</string>
+         </property>
+         <property name="buddy">
+          <cstring>spectra_per_step_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="2">
+        <widget class="QPushButton" name="scan_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Scan the stage with the above parameters</string>
+         </property>
+         <property name="text">
+          <string>S&amp;tart scan</string>
+         </property>
+        </widget>
+       </item>
+       <item row="32" column="0">
+        <widget class="QLabel" name="apply_limit_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Determine and apply a limit using pypret.
+</string>
+         </property>
+         <property name="text">
+          <string>Apply limit</string>
+         </property>
+         <property name="buddy">
+          <cstring>apply_limit_checkbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="30" column="2">
+        <widget class="QPushButton" name="export_button">
+         <property name="toolTip">
+          <string>Export data to a file (or .dat files)</string>
+         </property>
+         <property name="text">
+          <string>Export</string>
+         </property>
+        </widget>
+       </item>
+       <item row="25" column="0">
+        <widget class="QLabel" name="nonlinear_process_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>The non-linear process to use
+</string>
+         </property>
+         <property name="text">
+          <string>Non-linear process</string>
+         </property>
+         <property name="buddy">
+          <cstring>nonlinear_combo</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="TyphosRelatedSuiteButton" name="stage_suite_button">
+         <property name="toolTip">
+          <string>Open a typhos screen for the stage</string>
+         </property>
+         <property name="text">
+          <string>stage_name</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="TyphosRelatedSuiteButton" name="spectrometer_suite_button">
+         <property name="toolTip">
+          <string>Open a typhos screen for the spectrometer</string>
+         </property>
+         <property name="text">
+          <string>spectrometer_name</string>
+         </property>
+        </widget>
+       </item>
+       <item row="18" column="1">
+        <widget class="QDoubleSpinBox" name="wedge_angle_spin">
+         <property name="suffix">
+          <string> deg</string>
+         </property>
+         <property name="decimals">
+          <number>5</number>
+         </property>
+         <property name="minimum">
+          <double>-360.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>360.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>8.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="22" column="1">
+        <widget class="QDoubleSpinBox" name="fundamental_low_spinbox">
+         <property name="suffix">
+          <string> nm</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>100000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>700.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="22" column="0">
+        <widget class="QLabel" name="fundamental_range_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Fundamental spectrum window</string>
+         </property>
+         <property name="text">
+          <string>&amp;Fundamental range</string>
+         </property>
+         <property name="buddy">
+          <cstring>fundamental_low_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="scan_steps_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>S&amp;can steps</string>
+         </property>
+         <property name="buddy">
+          <cstring>scan_steps_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="0">
+        <widget class="QLabel" name="auto_fundamental_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Se&amp;t fundamental</string>
+         </property>
+         <property name="buddy">
+          <cstring>auto_fundamental_checkbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="37" column="0">
+        <widget class="QLabel" name="debug_mode_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Phase blanking threshold</string>
+         </property>
+         <property name="text">
+          <string>Debug mode</string>
+         </property>
+         <property name="buddy">
+          <cstring>debug_mode_checkbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="spectrometer_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Spectrometer</string>
+         </property>
+         <property name="buddy">
+          <cstring>spectrometer_suite_button</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="stage_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Stage</string>
+         </property>
+         <property name="buddy">
+          <cstring>stage_suite_button</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="35" column="0">
+        <widget class="QLabel" name="phase_blanking_threshold_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Phase blanking threshold</string>
+         </property>
+         <property name="text">
+          <string>Threshold</string>
+         </property>
+         <property name="buddy">
+          <cstring>phase_blanking_threshold_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="27" column="1">
+        <widget class="SolverComboBox" name="solver_combo">
+         <property name="toolTip">
+          <string>Retriever solver to use</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="2">
+        <widget class="QDoubleSpinBox" name="scan_wavelength_high_spinbox">
+         <property name="toolTip">
+          <string>Upper scan wavelength</string>
+         </property>
+         <property name="suffix">
+          <string> nm</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>100000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>450.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="15" column="0" colspan="3">
+        <widget class="QLabel" name="scan_status_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Scan: not in progress</string>
          </property>
         </widget>
        </item>
@@ -875,27 +996,18 @@
          </property>
         </widget>
        </item>
-       <item row="32" column="0">
-        <widget class="QLabel" name="phase_blanking_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Enable phase blanking with pypret masking</string>
-         </property>
+       <item row="34" column="1">
+        <widget class="QCheckBox" name="phase_blanking_checkbox">
          <property name="text">
-          <string>Phase blanking</string>
+          <string/>
          </property>
-         <property name="buddy">
-          <cstring>phase_blanking_checkbox</cstring>
+         <property name="checked">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
-       <item row="31" column="0">
-        <widget class="QLabel" name="oversampling_label">
+       <item row="19" column="0">
+        <widget class="QLabel" name="blur_sigma_label">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -903,13 +1015,49 @@
           </sizepolicy>
          </property>
          <property name="toolTip">
-          <string>Oversampling</string>
+          <string>Strength of Gaussian blur applied to raw data (standard deviations).
+</string>
          </property>
          <property name="text">
-          <string>Oversampling</string>
+          <string>Blur sigma</string>
          </property>
          <property name="buddy">
-          <cstring>oversampling_spinbox</cstring>
+          <cstring>blur_sigma_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="22" column="2">
+        <widget class="QDoubleSpinBox" name="fundamental_high_spinbox">
+         <property name="suffix">
+          <string> nm</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>1000000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>900.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="30" column="0">
+        <widget class="QPushButton" name="update_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Recalculate using the current retriever settings</string>
+         </property>
+         <property name="text">
+          <string>Recalculate</string>
          </property>
         </widget>
        </item>
@@ -922,34 +1070,15 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>Scan range</string>
+          <string>&amp;Scan range</string>
          </property>
          <property name="buddy">
           <cstring>scan_start_spinbox</cstring>
          </property>
         </widget>
        </item>
-       <item row="23" column="1" colspan="2">
-        <widget class="QDoubleSpinBox" name="freq_bandwidth_spinbox">
-         <property name="suffix">
-          <string> nm</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>0.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>100000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>800.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="21" column="0">
-        <widget class="QLabel" name="iterations_label">
+       <item row="29" column="0">
+        <widget class="QLabel" name="plot_position_label">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -957,101 +1086,23 @@
           </sizepolicy>
          </property>
          <property name="toolTip">
-          <string>Maximum number of iterations for the retriever</string>
+          <string>Phase blanking threshold</string>
          </property>
          <property name="text">
-          <string>Iterations</string>
+          <string>Plot position</string>
          </property>
          <property name="buddy">
-          <cstring>iterations_spinbox</cstring>
+          <cstring>plot_position_spinbox</cstring>
          </property>
         </widget>
        </item>
-       <item row="30" column="0">
-        <widget class="QLabel" name="apply_limit_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Determine and apply a limit using pypret.
-</string>
-         </property>
+       <item row="29" column="2">
+        <widget class="QCheckBox" name="plot_position_auto_checkbox">
          <property name="text">
-          <string>Apply limit</string>
-         </property>
-         <property name="buddy">
-          <cstring>apply_limit_checkbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="21" column="1" colspan="2">
-        <widget class="QSpinBox" name="iterations_spinbox">
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>10000</number>
-         </property>
-         <property name="value">
-          <number>30</number>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="0">
-        <widget class="QLabel" name="auto_fundamental_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Set fundamental</string>
-         </property>
-         <property name="buddy">
-          <cstring>scan_wavelength_low_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="0">
-        <widget class="QLabel" name="save_automatically_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Auto save</string>
-         </property>
-         <property name="buddy">
-          <cstring>scan_wavelength_low_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="1" colspan="2">
-        <widget class="QCheckBox" name="auto_fundamental_checkbox">
-         <property name="toolTip">
-          <string>Automatically use center of scan range for fundamental spectrum</string>
-         </property>
-         <property name="text">
-          <string/>
+          <string>Set automatically</string>
          </property>
          <property name="checked">
           <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="1" colspan="2">
-        <widget class="QCheckBox" name="save_automatically_checkbox">
-         <property name="toolTip">
-          <string>Save scan data automatically (in npz format) to the specified directory</string>
-         </property>
-         <property name="text">
-          <string/>
          </property>
         </widget>
        </item>
@@ -1331,6 +1382,8 @@
   <tabstop>scan_steps_spinbox</tabstop>
   <tabstop>spectra_per_step_spinbox</tabstop>
   <tabstop>dwell_time_spinbox</tabstop>
+  <tabstop>auto_fundamental_checkbox</tabstop>
+  <tabstop>save_automatically_checkbox</tabstop>
   <tabstop>take_fundamental_button</tabstop>
   <tabstop>scan_button</tabstop>
   <tabstop>wedge_angle_spin</tabstop>
@@ -1344,13 +1397,15 @@
   <tabstop>nonlinear_combo</tabstop>
   <tabstop>pulse_analysis_combo</tabstop>
   <tabstop>solver_combo</tabstop>
+  <tabstop>plot_position_spinbox</tabstop>
+  <tabstop>plot_position_auto_checkbox</tabstop>
   <tabstop>update_button</tabstop>
   <tabstop>import_button</tabstop>
   <tabstop>export_button</tabstop>
   <tabstop>apply_limit_checkbox</tabstop>
+  <tabstop>oversampling_spinbox</tabstop>
   <tabstop>phase_blanking_checkbox</tabstop>
   <tabstop>phase_blanking_threshold_spinbox</tabstop>
-  <tabstop>oversampling_spinbox</tabstop>
   <tabstop>debug_mode_checkbox</tabstop>
   <tabstop>replot_button</tabstop>
   <tabstop>save_plots_button</tabstop>

--- a/las_dispersion_scan/ui/main.ui
+++ b/las_dispersion_scan/ui/main.ui
@@ -980,7 +980,7 @@
         </widget>
        </item>
        <item>
-        <widget class="PlotWidget" name="dscan_difference_plot" native="true">
+        <widget class="SpectrumPlotWidget" name="dscan_difference_plot" native="true">
          <property name="sizePolicy">
           <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
            <horstretch>0</horstretch>
@@ -990,7 +990,7 @@
         </widget>
        </item>
        <item>
-        <widget class="PlotWidget" name="dscan_retrieved_plot" native="true">
+        <widget class="SpectrumPlotWidget" name="dscan_retrieved_plot" native="true">
          <property name="sizePolicy">
           <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
            <horstretch>0</horstretch>
@@ -1000,7 +1000,7 @@
         </widget>
        </item>
        <item>
-        <widget class="PlotWidget" name="dscan_acquired_plot" native="true">
+        <widget class="SpectrumPlotWidget" name="dscan_acquired_plot" native="true">
          <property name="sizePolicy">
           <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
            <horstretch>0</horstretch>
@@ -1205,6 +1205,12 @@
    <class>SolverComboBox</class>
    <extends>QComboBox</extends>
    <header>las_dispersion_scan.widgets</header>
+  </customwidget>
+  <customwidget>
+   <class>SpectrumPlotWidget</class>
+   <extends>QWidget</extends>
+   <header>las_dispersion_scan.widgets</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/las_dispersion_scan/ui/main.ui
+++ b/las_dispersion_scan/ui/main.ui
@@ -264,8 +264,14 @@
          <property name="toolTip">
           <string/>
          </property>
+         <property name="precision" stdset="0">
+          <number>3</number>
+         </property>
          <property name="showUnits" stdset="0">
           <bool>true</bool>
+         </property>
+         <property name="precisionFromPV" stdset="0">
+          <bool>false</bool>
          </property>
         </widget>
        </item>

--- a/las_dispersion_scan/ui/main.ui
+++ b/las_dispersion_scan/ui/main.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>985</width>
-    <height>912</height>
+    <height>968</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,17 +27,7 @@
        </size>
       </property>
       <layout class="QGridLayout" name="plot_grid_layout">
-       <item row="5" column="1">
-        <widget class="QSpinBox" name="scan_steps_spinbox">
-         <property name="minimum">
-          <number>5</number>
-         </property>
-         <property name="maximum">
-          <number>10000</number>
-         </property>
-        </widget>
-       </item>
-       <item row="19" column="0">
+       <item row="21" column="0">
         <widget class="QLabel" name="center_banwidth_label">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -56,20 +46,224 @@
          </property>
         </widget>
        </item>
-       <item row="16" column="1" colspan="2">
-        <widget class="QSpinBox" name="num_grid_points_spinbox">
-         <property name="minimum">
-          <number>10</number>
-         </property>
-         <property name="maximum">
-          <number>100000</number>
-         </property>
-         <property name="value">
-          <number>3000</number>
+       <item row="2" column="2">
+        <widget class="PyDMLabel" name="spectrometer_status_label">
+         <property name="toolTip">
+          <string/>
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="30" column="1">
+        <widget class="QCheckBox" name="phase_blanking_checkbox">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="20" column="0">
+        <widget class="QLabel" name="fundamental_range_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Fundamental spectrum window</string>
+         </property>
+         <property name="text">
+          <string>Fundamental range</string>
+         </property>
+         <property name="buddy">
+          <cstring>fundamental_low_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0">
+        <widget class="QLabel" name="dwell_time_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Dwell time</string>
+         </property>
+         <property name="buddy">
+          <cstring>scan_wavelength_low_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="TyphosRelatedSuiteButton" name="stage_suite_button">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="text">
+          <string>stage_name</string>
+         </property>
+        </widget>
+       </item>
+       <item row="16" column="0">
+        <widget class="QLabel" name="wedge_angle_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>The wedge angle (for traditional d-scan, not grating)
+</string>
+         </property>
+         <property name="text">
+          <string>Wedge angle</string>
+         </property>
+         <property name="buddy">
+          <cstring>wedge_angle_spin</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="20" column="1">
+        <widget class="QDoubleSpinBox" name="fundamental_low_spinbox">
+         <property name="suffix">
+          <string> nm</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>100000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>700.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="24" column="1" colspan="2">
+        <widget class="PulseAnalysisComboBox" name="pulse_analysis_combo">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="scan_wavelength_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Wavelengths</string>
+         </property>
+         <property name="buddy">
+          <cstring>scan_wavelength_low_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="27" column="1">
+        <widget class="QLabel" name="plot_settings_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Plot settings</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="32" column="1">
+        <widget class="QCheckBox" name="debug_mode_checkbox">
+         <property name="toolTip">
+          <string>Show all available debug plots in separate windows after pulse retrieval</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="2">
+        <widget class="QDoubleSpinBox" name="scan_wavelength_high_spinbox">
+         <property name="suffix">
+          <string> nm</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>100000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>450.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="31" column="0">
+        <widget class="QLabel" name="phase_blanking_threshold_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Phase blanking threshold</string>
+         </property>
+         <property name="text">
+          <string>Threshold</string>
+         </property>
+         <property name="buddy">
+          <cstring>phase_blanking_threshold_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="17" column="1" colspan="2">
+        <widget class="QSpinBox" name="blur_sigma_spinbox">
+         <property name="suffix">
+          <string> stdev</string>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="0" colspan="3">
+        <widget class="QProgressBar" name="scan_progress">
+         <property name="value">
+          <number>24</number>
+         </property>
+         <property name="textVisible">
+          <bool>true</bool>
+         </property>
+         <property name="invertedAppearance">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1">
         <widget class="QDoubleSpinBox" name="dwell_time_spinbox">
          <property name="suffix">
           <string> sec</string>
@@ -88,55 +282,62 @@
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
-        <widget class="QPushButton" name="take_fundamental_button">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Take fundamental</string>
-         </property>
-        </widget>
-       </item>
-       <item row="30" column="0">
-        <widget class="QLabel" name="debug_mode_label">
+       <item row="5" column="0">
+        <widget class="QLabel" name="scan_steps_label">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="toolTip">
-          <string>Phase blanking threshold</string>
-         </property>
          <property name="text">
-          <string>Debug mode</string>
+          <string>Scan steps</string>
          </property>
          <property name="buddy">
-          <cstring>debug_mode_checkbox</cstring>
+          <cstring>scan_steps_spinbox</cstring>
          </property>
         </widget>
        </item>
-       <item row="31" column="2">
-        <widget class="QPushButton" name="replot_button">
+       <item row="26" column="1">
+        <widget class="QPushButton" name="import_button">
          <property name="toolTip">
-          <string>Export data to a file</string>
+          <string>Import data from previous scans</string>
          </property>
          <property name="text">
-          <string>Replot</string>
+          <string>Import</string>
          </property>
         </widget>
        </item>
-       <item row="24" column="2">
+       <item row="34" column="1">
+        <spacer name="left_spacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="26" column="2">
         <widget class="QPushButton" name="export_button">
          <property name="toolTip">
           <string>Export data to a file</string>
          </property>
          <property name="text">
           <string>Export</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="0">
+        <widget class="QCheckBox" name="save_automatically_checkbox">
+         <property name="toolTip">
+          <string>Save scan data automatically (in npz format) to the specified directory</string>
+         </property>
+         <property name="text">
+          <string>Auto save</string>
          </property>
         </widget>
        </item>
@@ -156,6 +357,265 @@
          </property>
          <property name="value">
           <double>25.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="32" column="0">
+        <widget class="QLabel" name="debug_mode_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Phase blanking threshold</string>
+         </property>
+         <property name="text">
+          <string>Debug mode</string>
+         </property>
+         <property name="buddy">
+          <cstring>debug_mode_checkbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="spectrometer_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Spectrometer</string>
+         </property>
+         <property name="buddy">
+          <cstring>spectrometer_suite_button</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QDoubleSpinBox" name="scan_wavelength_low_spinbox">
+         <property name="suffix">
+          <string> nm</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>0.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>1000000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>350.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QSpinBox" name="scan_steps_spinbox">
+         <property name="minimum">
+          <number>5</number>
+         </property>
+         <property name="maximum">
+          <number>10000</number>
+         </property>
+        </widget>
+       </item>
+       <item row="18" column="0">
+        <widget class="QLabel" name="grid_points_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Number of grid points in frequency and time axes.
+</string>
+         </property>
+         <property name="text">
+          <string>Grid points</string>
+         </property>
+         <property name="buddy">
+          <cstring>num_grid_points_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="28" column="0">
+        <widget class="QLabel" name="apply_limit_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Determine and apply a limit using pypret.
+</string>
+         </property>
+         <property name="text">
+          <string>Apply limit</string>
+         </property>
+         <property name="buddy">
+          <cstring>apply_limit_checkbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="19" column="0">
+        <widget class="QLabel" name="iterations_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Maximum number of iterations for the retriever</string>
+         </property>
+         <property name="text">
+          <string>Iterations</string>
+         </property>
+         <property name="buddy">
+          <cstring>iterations_spinbox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="29" column="1" colspan="2">
+        <widget class="QSpinBox" name="oversampling_spinbox">
+         <property name="minimum">
+          <number>0</number>
+         </property>
+         <property name="maximum">
+          <number>10000</number>
+         </property>
+         <property name="value">
+          <number>8</number>
+         </property>
+        </widget>
+       </item>
+       <item row="23" column="0">
+        <widget class="QLabel" name="nonlinear_process_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>The non-linear process to use
+</string>
+         </property>
+         <property name="text">
+          <string>Non-linear process</string>
+         </property>
+         <property name="buddy">
+          <cstring>nonlinear_combo</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="18" column="1" colspan="2">
+        <widget class="QSpinBox" name="num_grid_points_spinbox">
+         <property name="minimum">
+          <number>10</number>
+         </property>
+         <property name="maximum">
+          <number>100000</number>
+         </property>
+         <property name="value">
+          <number>3000</number>
+         </property>
+        </widget>
+       </item>
+       <item row="22" column="1" colspan="2">
+        <widget class="MaterialComboBox" name="material_combo"/>
+       </item>
+       <item row="23" column="1" colspan="2">
+        <widget class="NonlinearComboBox" name="nonlinear_combo"/>
+       </item>
+       <item row="9" column="2">
+        <widget class="QPushButton" name="scan_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>&amp;Start scan</string>
+         </property>
+        </widget>
+       </item>
+       <item row="28" column="1">
+        <widget class="QCheckBox" name="apply_limit_checkbox">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="1">
+        <widget class="QPushButton" name="take_fundamental_button">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Take fundamental</string>
+         </property>
+        </widget>
+       </item>
+       <item row="16" column="1" colspan="2">
+        <widget class="QDoubleSpinBox" name="wedge_angle_spin">
+         <property name="suffix">
+          <string> deg</string>
+         </property>
+         <property name="decimals">
+          <number>5</number>
+         </property>
+         <property name="minimum">
+          <double>-360.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>360.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>8.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="25" column="0">
+        <widget class="QLabel" name="solver_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>The retriever solver to use. </string>
+         </property>
+         <property name="text">
+          <string>Solver</string>
+         </property>
+         <property name="buddy">
+          <cstring>solver_combo</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="33" column="2">
+        <widget class="QPushButton" name="replot_button">
+         <property name="toolTip">
+          <string>Export data to a file</string>
+         </property>
+         <property name="text">
+          <string>Replot</string>
          </property>
         </widget>
        </item>
@@ -181,74 +641,6 @@
          </property>
         </widget>
        </item>
-       <item row="7" column="2">
-        <widget class="QPushButton" name="scan_button">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>&amp;Start scan</string>
-         </property>
-        </widget>
-       </item>
-       <item row="27" column="1" colspan="2">
-        <widget class="QSpinBox" name="oversampling_spinbox">
-         <property name="minimum">
-          <number>0</number>
-         </property>
-         <property name="maximum">
-          <number>10000</number>
-         </property>
-         <property name="value">
-          <number>8</number>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="scan_wavelength_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Wavelengths</string>
-         </property>
-         <property name="buddy">
-          <cstring>scan_wavelength_low_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QDoubleSpinBox" name="scan_wavelength_low_spinbox">
-         <property name="suffix">
-          <string> nm</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>0.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>1000000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>350.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="2">
-        <widget class="PyDMLabel" name="spectrometer_status_label">
-         <property name="toolTip">
-          <string/>
-         </property>
-        </widget>
-       </item>
        <item row="2" column="1">
         <widget class="TyphosRelatedSuiteButton" name="spectrometer_suite_button">
          <property name="toolTip">
@@ -259,282 +651,7 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="2">
-        <widget class="PyDMLabel" name="stage_status_label">
-         <property name="toolTip">
-          <string/>
-         </property>
-         <property name="precision" stdset="0">
-          <number>3</number>
-         </property>
-         <property name="showUnits" stdset="0">
-          <bool>true</bool>
-         </property>
-         <property name="precisionFromPV" stdset="0">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="18" column="1">
-        <widget class="QDoubleSpinBox" name="fundamental_low_spinbox">
-         <property name="suffix">
-          <string> nm</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>0.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>100000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>700.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="28" column="0">
-        <widget class="QLabel" name="phase_blanking_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Enable phase blanking with pypret masking</string>
-         </property>
-         <property name="text">
-          <string>Phase blanking</string>
-         </property>
-         <property name="buddy">
-          <cstring>phase_blanking_checkbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="0" colspan="3">
-        <widget class="QLabel" name="scan_status_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Scan: not in progress</string>
-         </property>
-        </widget>
-       </item>
-       <item row="20" column="1" colspan="2">
-        <widget class="MaterialComboBox" name="material_combo"/>
-       </item>
-       <item row="3" column="1">
-        <widget class="QDoubleSpinBox" name="scan_start_spinbox">
-         <property name="suffix">
-          <string> mm</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>-10000000000.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>10000000000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>23.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="scan_steps_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Scan steps</string>
-         </property>
-         <property name="buddy">
-          <cstring>scan_steps_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="25" column="1">
-        <widget class="QLabel" name="plot_settings_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Plot settings</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="23" column="1" colspan="2">
-        <widget class="SolverComboBox" name="solver_combo"/>
-       </item>
-       <item row="21" column="1" colspan="2">
-        <widget class="NonlinearComboBox" name="nonlinear_combo"/>
-       </item>
-       <item row="27" column="0">
-        <widget class="QLabel" name="oversampling_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Oversampling</string>
-         </property>
-         <property name="text">
-          <string>Oversampling</string>
-         </property>
-         <property name="buddy">
-          <cstring>oversampling_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="18" column="0">
-        <widget class="QLabel" name="fundamental_range_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Fundamental spectrum window</string>
-         </property>
-         <property name="text">
-          <string>Fundamental range</string>
-         </property>
-         <property name="buddy">
-          <cstring>fundamental_low_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="21" column="0">
-        <widget class="QLabel" name="nonlinear_process_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>The non-linear process to use
-</string>
-         </property>
-         <property name="text">
-          <string>Non-linear process</string>
-         </property>
-         <property name="buddy">
-          <cstring>nonlinear_combo</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="19" column="1" colspan="2">
-        <widget class="QDoubleSpinBox" name="freq_bandwidth_spinbox">
-         <property name="suffix">
-          <string> nm</string>
-         </property>
-         <property name="decimals">
-          <number>3</number>
-         </property>
-         <property name="minimum">
-          <double>0.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>100000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>800.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="spectrometer_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Spectrometer</string>
-         </property>
-         <property name="buddy">
-          <cstring>spectrometer_suite_button</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="14" column="1" colspan="2">
-        <widget class="QDoubleSpinBox" name="wedge_angle_spin">
-         <property name="suffix">
-          <string> deg</string>
-         </property>
-         <property name="decimals">
-          <number>5</number>
-         </property>
-         <property name="minimum">
-          <double>-360.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>360.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>8.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0">
-        <widget class="QCheckBox" name="save_automatically_checkbox">
-         <property name="toolTip">
-          <string>Save scan data automatically (in npz format) to the specified directory</string>
-         </property>
-         <property name="text">
-          <string>Auto save</string>
-         </property>
-        </widget>
-       </item>
-       <item row="22" column="0">
-        <widget class="QLabel" name="pulse_analysis_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>The pulse analysis method to use
-</string>
-         </property>
-         <property name="text">
-          <string>Pulse analysis</string>
-         </property>
-         <property name="buddy">
-          <cstring>pulse_analysis_combo</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="13" column="0" colspan="3">
+       <item row="15" column="0" colspan="3">
         <widget class="QLabel" name="retriever_settings_label">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
@@ -556,7 +673,7 @@
          </property>
         </widget>
        </item>
-       <item row="17" column="1" colspan="2">
+       <item row="19" column="1" colspan="2">
         <widget class="QSpinBox" name="iterations_spinbox">
          <property name="minimum">
           <number>1</number>
@@ -569,15 +686,8 @@
          </property>
         </widget>
        </item>
-       <item row="15" column="1" colspan="2">
-        <widget class="QSpinBox" name="blur_sigma_spinbox">
-         <property name="suffix">
-          <string> stdev</string>
-         </property>
-        </widget>
-       </item>
-       <item row="17" column="0">
-        <widget class="QLabel" name="iterations_label">
+       <item row="29" column="0">
+        <widget class="QLabel" name="oversampling_label">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -585,27 +695,33 @@
           </sizepolicy>
          </property>
          <property name="toolTip">
-          <string>Maximum number of iterations for the retriever</string>
+          <string>Oversampling</string>
          </property>
          <property name="text">
-          <string>Iterations</string>
+          <string>Oversampling</string>
          </property>
          <property name="buddy">
-          <cstring>iterations_spinbox</cstring>
+          <cstring>oversampling_spinbox</cstring>
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
-        <widget class="TyphosRelatedSuiteButton" name="stage_suite_button">
+       <item row="1" column="2">
+        <widget class="PyDMLabel" name="stage_status_label">
          <property name="toolTip">
           <string/>
          </property>
-         <property name="text">
-          <string>stage_name</string>
+         <property name="precision" stdset="0">
+          <number>3</number>
+         </property>
+         <property name="showUnits" stdset="0">
+          <bool>true</bool>
+         </property>
+         <property name="precisionFromPV" stdset="0">
+          <bool>false</bool>
          </property>
         </widget>
        </item>
-       <item row="20" column="0">
+       <item row="22" column="0">
         <widget class="QLabel" name="material_label">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -625,8 +741,43 @@
          </property>
         </widget>
        </item>
-       <item row="14" column="0">
-        <widget class="QLabel" name="wedge_angle_label">
+       <item row="1" column="0">
+        <widget class="QLabel" name="stage_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Stage</string>
+         </property>
+         <property name="buddy">
+          <cstring>stage_suite_button</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QDoubleSpinBox" name="scan_start_spinbox">
+         <property name="suffix">
+          <string> mm</string>
+         </property>
+         <property name="decimals">
+          <number>3</number>
+         </property>
+         <property name="minimum">
+          <double>-10000000000.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>10000000000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>23.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="24" column="0">
+        <widget class="QLabel" name="pulse_analysis_label">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -634,37 +785,40 @@
           </sizepolicy>
          </property>
          <property name="toolTip">
-          <string>The wedge angle (for traditional d-scan, not grating)
+          <string>The pulse analysis method to use
 </string>
          </property>
          <property name="text">
-          <string>Wedge angle</string>
+          <string>Pulse analysis</string>
          </property>
          <property name="buddy">
-          <cstring>wedge_angle_spin</cstring>
+          <cstring>pulse_analysis_combo</cstring>
          </property>
         </widget>
        </item>
-       <item row="4" column="2">
-        <widget class="QDoubleSpinBox" name="scan_wavelength_high_spinbox">
-         <property name="suffix">
-          <string> nm</string>
+       <item row="25" column="1" colspan="2">
+        <widget class="SolverComboBox" name="solver_combo"/>
+       </item>
+       <item row="30" column="0">
+        <widget class="QLabel" name="phase_blanking_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
-         <property name="decimals">
-          <number>3</number>
+         <property name="toolTip">
+          <string>Enable phase blanking with pypret masking</string>
          </property>
-         <property name="minimum">
-          <double>0.000000000000000</double>
+         <property name="text">
+          <string>Phase blanking</string>
          </property>
-         <property name="maximum">
-          <double>100000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>450.000000000000000</double>
+         <property name="buddy">
+          <cstring>phase_blanking_checkbox</cstring>
          </property>
         </widget>
        </item>
-       <item row="18" column="2">
+       <item row="20" column="2">
         <widget class="QDoubleSpinBox" name="fundamental_high_spinbox">
          <property name="suffix">
           <string> nm</string>
@@ -683,33 +837,26 @@
          </property>
         </widget>
        </item>
-       <item row="28" column="1">
-        <widget class="QCheckBox" name="phase_blanking_checkbox">
-         <property name="text">
-          <string/>
+       <item row="21" column="1" colspan="2">
+        <widget class="QDoubleSpinBox" name="freq_bandwidth_spinbox">
+         <property name="suffix">
+          <string> nm</string>
          </property>
-         <property name="checked">
-          <bool>true</bool>
+         <property name="decimals">
+          <number>3</number>
          </property>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="dwell_time_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+         <property name="minimum">
+          <double>0.000000000000000</double>
          </property>
-         <property name="text">
-          <string>Dwell time</string>
+         <property name="maximum">
+          <double>100000.000000000000000</double>
          </property>
-         <property name="buddy">
-          <cstring>scan_wavelength_low_spinbox</cstring>
+         <property name="value">
+          <double>800.000000000000000</double>
          </property>
         </widget>
        </item>
-       <item row="15" column="0">
+       <item row="17" column="0">
         <widget class="QLabel" name="blur_sigma_label">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -729,7 +876,20 @@
          </property>
         </widget>
        </item>
-       <item row="29" column="1" colspan="2">
+       <item row="13" column="0" colspan="3">
+        <widget class="QLabel" name="scan_status_label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Scan: not in progress</string>
+         </property>
+        </widget>
+       </item>
+       <item row="31" column="1" colspan="2">
         <widget class="QDoubleSpinBox" name="phase_blanking_threshold_spinbox">
          <property name="suffix">
           <string/>
@@ -745,33 +905,6 @@
          </property>
          <property name="value">
           <double>0.010000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="22" column="1" colspan="2">
-        <widget class="PulseAnalysisComboBox" name="pulse_analysis_combo">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="26" column="0">
-        <widget class="QLabel" name="apply_limit_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Determine and apply a limit using pypret.
-</string>
-         </property>
-         <property name="text">
-          <string>Apply limit</string>
-         </property>
-         <property name="buddy">
-          <cstring>apply_limit_checkbox</cstring>
          </property>
         </widget>
        </item>
@@ -791,102 +924,8 @@
          </property>
         </widget>
        </item>
-       <item row="24" column="1">
-        <widget class="QPushButton" name="import_button">
-         <property name="toolTip">
-          <string>Import data from previous scans</string>
-         </property>
-         <property name="text">
-          <string>Import</string>
-         </property>
-        </widget>
-       </item>
-       <item row="32" column="1">
-        <spacer name="left_spacer">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="30" column="1">
-        <widget class="QCheckBox" name="debug_mode_checkbox">
-         <property name="toolTip">
-          <string>Show all available debug plots in separate windows after pulse retrieval</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="checked">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="29" column="0">
-        <widget class="QLabel" name="phase_blanking_threshold_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Phase blanking threshold</string>
-         </property>
-         <property name="text">
-          <string>Threshold</string>
-         </property>
-         <property name="buddy">
-          <cstring>phase_blanking_threshold_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="23" column="0">
-        <widget class="QLabel" name="solver_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>The retriever solver to use. </string>
-         </property>
-         <property name="text">
-          <string>Solver</string>
-         </property>
-         <property name="buddy">
-          <cstring>solver_combo</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="16" column="0">
-        <widget class="QLabel" name="grid_points_label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>Number of grid points in frequency and time axes.
-</string>
-         </property>
-         <property name="text">
-          <string>Grid points</string>
-         </property>
-         <property name="buddy">
-          <cstring>num_grid_points_spinbox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="stage_label">
+       <item row="6" column="0">
+        <widget class="QLabel" name="per_step_spectra_label">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
            <horstretch>0</horstretch>
@@ -894,33 +933,23 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>Stage</string>
+          <string>Per-step spectra</string>
          </property>
          <property name="buddy">
-          <cstring>stage_suite_button</cstring>
+          <cstring>scan_steps_spinbox</cstring>
          </property>
         </widget>
        </item>
-       <item row="26" column="1">
-        <widget class="QCheckBox" name="apply_limit_checkbox">
-         <property name="text">
-          <string/>
+       <item row="6" column="1">
+        <widget class="QSpinBox" name="spectra_per_step_spinbox">
+         <property name="minimum">
+          <number>1</number>
          </property>
-         <property name="checked">
-          <bool>true</bool>
+         <property name="maximum">
+          <number>100</number>
          </property>
-        </widget>
-       </item>
-       <item row="10" column="0" colspan="3">
-        <widget class="QProgressBar" name="scan_progress">
          <property name="value">
-          <number>24</number>
-         </property>
-         <property name="textVisible">
-          <bool>true</bool>
-         </property>
-         <property name="invertedAppearance">
-          <bool>false</bool>
+          <number>1</number>
          </property>
         </widget>
        </item>
@@ -989,7 +1018,7 @@
              <string>Acquired</string>
             </property>
             <property name="checked">
-             <bool>false</bool>
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -999,7 +1028,7 @@
              <string>Retrieved</string>
             </property>
             <property name="checked">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
            </widget>
           </item>
@@ -1142,14 +1171,14 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>TyphosRelatedSuiteButton</class>
-   <extends>QPushButton</extends>
-   <header>typhos.related_display</header>
-  </customwidget>
-  <customwidget>
    <class>PyDMLabel</class>
    <extends>QLabel</extends>
    <header>pydm.widgets.label</header>
+  </customwidget>
+  <customwidget>
+   <class>TyphosRelatedSuiteButton</class>
+   <extends>QPushButton</extends>
+   <header>typhos.related_display</header>
   </customwidget>
   <customwidget>
    <class>PlotWidget</class>
@@ -1186,6 +1215,7 @@
   <tabstop>scan_wavelength_low_spinbox</tabstop>
   <tabstop>scan_wavelength_high_spinbox</tabstop>
   <tabstop>scan_steps_spinbox</tabstop>
+  <tabstop>spectra_per_step_spinbox</tabstop>
   <tabstop>dwell_time_spinbox</tabstop>
   <tabstop>save_automatically_checkbox</tabstop>
   <tabstop>take_fundamental_button</tabstop>

--- a/las_dispersion_scan/ui/main.ui
+++ b/las_dispersion_scan/ui/main.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>985</width>
+    <width>1235</width>
     <height>968</height>
    </rect>
   </property>

--- a/las_dispersion_scan/ui/main.ui
+++ b/las_dispersion_scan/ui/main.ui
@@ -987,6 +987,9 @@
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
+         <property name="plot_type" stdset="0">
+          <string>Difference</string>
+         </property>
         </widget>
        </item>
        <item>
@@ -997,6 +1000,9 @@
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
+         <property name="plot_type" stdset="0">
+          <string>Retrieved</string>
+         </property>
         </widget>
        </item>
        <item>
@@ -1006,6 +1012,9 @@
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
+         </property>
+         <property name="plot_type" stdset="0">
+          <string>Acquired</string>
          </property>
         </widget>
        </item>
@@ -1117,6 +1126,19 @@
          </property>
          <property name="invertedAppearance">
           <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="updating_plots_label">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Updating plots, please wait...</string>
          </property>
         </widget>
        </item>

--- a/las_dispersion_scan/utils.py
+++ b/las_dispersion_scan/utils.py
@@ -11,7 +11,7 @@ import pypret
 import pypret.frequencies
 import scipy
 import scipy.interpolate
-from qtpy import QtCore
+from qtpy import QtCore, QtWidgets
 
 SOURCE_PATH = pathlib.Path(__file__).resolve().parent
 
@@ -231,3 +231,10 @@ class ThreadWorker(QtCore.QThread):
             self.returned.emit(None, ex)
         else:
             self.returned.emit(self.return_value, None)
+
+
+def process_events(*, count: int = 100):
+    """Process Qt events."""
+    app = QtWidgets.QApplication.instance()
+    for _ in range(count):
+        app.processEvents()

--- a/las_dispersion_scan/widgets.py
+++ b/las_dispersion_scan/widgets.py
@@ -187,6 +187,7 @@ class DscanMain(DesignerDisplay, QtWidgets.QWidget):
     oversampling_label: QtWidgets.QLabel
     oversampling_spinbox: QtWidgets.QSpinBox
     params_label: QtWidgets.QLabel
+    spectra_per_step_spinbox: QtWidgets.QSpinBox
     phase_blanking_checkbox: QtWidgets.QCheckBox
     phase_blanking_label: QtWidgets.QLabel
     phase_blanking_threshold_label: QtWidgets.QLabel
@@ -558,6 +559,7 @@ class DscanMain(DesignerDisplay, QtWidgets.QWidget):
             for point in self.scan.run(
                 positions=list(positions),
                 dwell_time=dwell_time,
+                per_step_spectra=self.spectra_per_step_spinbox.value(),
             ):
                 self.new_scan_point.emit(point)
 

--- a/las_dispersion_scan/widgets.py
+++ b/las_dispersion_scan/widgets.py
@@ -317,7 +317,7 @@ class DscanMain(DesignerDisplay, QtWidgets.QWidget):
     def _update_title(self) -> None:
         title = "D-scan Diagnostic"
 
-        if self.devices is not None:
+        if self.devices is not None and self.devices.status.prefix:
             title = f"{title} ({self.devices.status.prefix})"
 
         if self.saved_filename is not None:
@@ -537,7 +537,7 @@ class DscanMain(DesignerDisplay, QtWidgets.QWidget):
     def _on_new_scan_point(self, data: dscan.ScanPointData) -> None:
         self.scan_progress.setValue(data.index + 1)
         self.scan_status_label.setText(
-            f"Acquired [{data.index + 1}] at {data.readback * 1e-3} mm"
+            f"Acquired [{data.index + 1}] at {data.readback * 1e-3:.3g} mm"
         )
 
     def _start_scan(self) -> None:

--- a/las_dispersion_scan/widgets.py
+++ b/las_dispersion_scan/widgets.py
@@ -315,12 +315,10 @@ class DscanMain(DesignerDisplay, QtWidgets.QWidget):
             )
 
     def _update_title(self) -> None:
-        if self.devices is not None:
-            prefix = self.devices.status.prefix
-        else:
-            prefix = None
+        title = "D-scan Diagnostic"
 
-        title = f"D-scan Diagnostic ({prefix})"
+        if self.devices is not None:
+            title = f"{title} ({self.devices.status.prefix})"
 
         if self.saved_filename is not None:
             title = f"{title}: {self.saved_filename}"

--- a/las_dispersion_scan/widgets.py
+++ b/las_dispersion_scan/widgets.py
@@ -93,7 +93,7 @@ class EnumComboBox(QtWidgets.QComboBox):
 
 
 class MaterialComboBox(EnumComboBox):
-    enum_default = options.Material.bk7
+    enum_default = options.Material.gratinga
 
 
 class NonlinearComboBox(EnumComboBox):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Add generic QMini and EpicsMotor loader (environment variable-configured PV prefixes)
* Remove status object prefix from window title if unspecified (as we are not propagating scan settings to EPICS just yet)

## Motivation and Context
Testing at XCS with class 4 laser

## How Has This Been Tested?
Interactive testing

## Where Has This Been Documented?
This PR text

## Screenshots (if appropriate):
