### PR TITLE
ENH/REF: move out retry functionality from scan

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,23 @@
 [flake8]
-exclude = .git,__pycache__,build,dist,versioneer.py,las_dispersion_scan/_version.py,docs/source/conf.py
+exclude = .git,__pycache__,build,dist,las_dispersion_scan/_version.py
 max-line-length = 88
 select = C,E,F,W,B,B950
-extend-ignore = E203, E501
+extend-ignore = E203, E501, E226, W503, W504
+
+# Explanation section:
+# B950
+#   This takes into account max-line-length but only triggers when the value
+#   has been exceeded by more than 10% (96 characters).
+# E203: Whitespace before ':'
+#   This is recommended by black in relation to slice formatting.
+# E501: Line too long (82 > 79 characters)
+#   Our line length limit is 88 (above 79 defined in E501).  Ignore it.
+# E226: Missing whitespace around arithmetic operator
+#   This is a stylistic choice which you'll find everywhere in pcdsdevices, for
+#   example.  Formulas can be easier to read when operators and operands
+#   have no whitespace between them.
+#
+# W503: Line break occurred before a binary operator
+# W504: Line break occurred after a binary operator
+#   flake8 wants us to choose one of the above two.  Our choice
+#   is to make no decision.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
     -   id: no-commit-to-branch
     -   id: trailing-whitespace
@@ -18,18 +18,18 @@ repos:
     -   id: debug-statements
 
 -   repo: https://github.com/pycqa/flake8.git
-    rev: 3.9.2
+    rev: 6.0.0
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/timothycrosley/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     -   id: isort
         args: ["--profile", "black"]
 
 - repo: https://github.com/psf/black
-  rev: 22.10.0
+  rev: 23.1.0
   hooks:
     - id: black
       language_version: python3

--- a/las_dispersion_scan/dscan.py
+++ b/las_dispersion_scan/dscan.py
@@ -682,8 +682,7 @@ class AcquisitionScan:
 
         while remaining and not self._stop:
             idx, setpoint = remaining[0]
-            #self.stage.set(setpoint).wait(timeout=timeout)
-            self.stage.set(setpoint)
+            self.stage.set(setpoint).wait(timeout=timeout)
             t0 = time.monotonic()
             while not self._stop and time.monotonic() - t0 < dwell_time:
                 time.sleep(dwell_time / 10.0)
@@ -691,21 +690,6 @@ class AcquisitionScan:
             if self._stop:
                 break
 
-            n = 0
-            while abs(self.stage.wm()-setpoint)>0.01: # Then try again
-                n += 1
-                print("Stage is not in position, try # {}".format(n))
-                self.stage.move(setpoint, wait=False, timeout=timeout)
-                t0 = time.monotonic()
-                while not self._stop and time.monotonic() - t0 < dwell_time:
-                    time.sleep(1.0)
-
-                if self._stop:
-                    break
-
-                if n == 10:
-                    break
-                
             data = ScanPointData.from_devices(
                 index=idx,
                 setpoint=setpoint,
@@ -1585,7 +1569,10 @@ class PypretResult:
         )
 
         # Clean scan by truncating wavelength
-        (self.scan.wavelengths, self.scan.intensities,) = self.scan.truncate_wavelength(
+        (
+            self.scan.wavelengths,
+            self.scan.intensities,
+        ) = self.scan.truncate_wavelength(
             range_low=self.spec_scan_range[0] * 1e-9,
             range_high=self.spec_scan_range[1] * 1e-9,
         )

--- a/las_dispersion_scan/loaders/qmini_and_dual_elliptec.py
+++ b/las_dispersion_scan/loaders/qmini_and_dual_elliptec.py
@@ -2,14 +2,13 @@ import os
 
 from ophyd import Component as Cpt
 from ophyd import DerivedSignal, Signal
+from ophyd.pseudopos import real_position_argument
 from ophyd.signal import AttributeSignal
-from ophyd.pseudopos import (PseudoSingle, pseudo_position_argument,
-                             real_position_argument)
 from pcdsdevices.lasers import elliptec
 from pcdsdevices.pseudopos import SyncAxis
 
-from las_dispersion_scan.devices import Qmini
-from las_dispersion_scan.loaders.qmini_and_epicsmotor import EpicsMotor
+from ..devices import Qmini
+from ..motion import move_with_retries
 
 qmini_prefix = os.environ.get("QMINI_PREFIX", "LAS:LLN:QMINI:01")
 stage_prefix = os.environ.get("MOTOR_PREFIX", "IOC:TST:DScan:")
@@ -19,20 +18,47 @@ motor_units = os.environ.get("MOTOR_UNITS", "mm")
 
 spectrometer = Qmini(qmini_prefix, name=qmini_name)
 
-if motor_units:
 
-    class EllLinear(elliptec.EllLinear):
-        @property
-        def egu(self) -> str:
-            return motor_units
+class EllLinear(elliptec.EllLinear):
+    _stop_requested: bool
 
-else:
-    EllLinear = elliptec.EllLinear
+    def __init__(self, *args, **kwargs):
+        self._stop_requested = False
+        super().__init__(*args, **kwargs)
+
+    def stop(self, *args, **kwargs):
+        self._stop_requested = True
+        super().stop(*args, **kwargs)
+
+    @property
+    def egu(self) -> str:
+        return motor_units
+
+    def set(
+        self,
+        position: float,
+        *,
+        wait: bool = True,
+        retry_timeout: float = 1.0,
+        retry_deadband: float = 0.01,
+        max_retries: int = 10,
+        timeout: float = 10.0,
+        **kwargs
+    ):
+        self._stop_requested = False
+        return move_with_retries(
+            self,
+            position=position,
+            retry_timeout=retry_timeout,
+            retry_deadband=retry_deadband,
+            max_retries=max_retries,
+            timeout=timeout,
+        )
 
 
 class DualElliptec(SyncAxis):
-    upstream = Cpt(EllLinear, '', port=0, channel=1, atol=0.05)
-    downstream = Cpt(EllLinear, '', port=0, channel=2, atol=0.05)
+    upstream = Cpt(EllLinear, "", port=0, channel=1, atol=0.05)
+    downstream = Cpt(EllLinear, "", port=0, channel=2, atol=0.05)
 
     user_setpoint = Cpt(AttributeSignal, attr="_user_setpoint_change")
     user_readback = Cpt(DerivedSignal, derived_from="sync.readback")
@@ -89,7 +115,6 @@ class DualElliptec(SyncAxis):
 
     @_user_setpoint_change.setter
     def _user_setpoint_change(self, value: float):
-        print("user setpoint changed", value)
         self.sync.move(value, wait=False)
 
     @property
@@ -115,14 +140,10 @@ class DualElliptec(SyncAxis):
         attr2 = real_pos._fields[1]
         pos2 = real_pos[1]
         calc2 = self.inverse_single(attr2, pos2)
-        calc = (calc1+calc2)/2
+        calc = (calc1 + calc2) / 2
         return self.PseudoPosition(sync=calc)
 
 
-stage = DualElliptec(
-    stage_prefix,
-    name=stage_name,
-    concurrent=True
-)
+stage = DualElliptec(stage_prefix, name=stage_name, concurrent=True)
 
-stage.warn_deadband=0.01
+stage.warn_deadband = 0.01

--- a/las_dispersion_scan/motion.py
+++ b/las_dispersion_scan/motion.py
@@ -1,0 +1,84 @@
+import threading
+import time
+
+import ophyd
+from ophyd.status import MoveStatus
+
+
+def move_with_retries(
+    positioner: ophyd.positioner.PositionerBase,
+    position: float,
+    *,
+    retry_timeout: float = 1.0,
+    retry_deadband: float = 0.01,
+    max_retries: int = 10,
+    timeout: float = 10.0,
+    stop_attribute: str = "_stop_requested",
+) -> MoveStatus:
+    """
+    Move ``positioner`` to ``position`` with optional retries.
+
+    Parameters
+    ----------
+    positioner : ophyd.positioner.PositionerBase
+        The positioner to move.
+    position : float
+        The position to move to.
+    retry_timeout : float, optional
+        Retry timeout, in seconds. Defaults to 1.0.
+    retry_deadband : float, optional
+        Retry deadband, in motor units. Defaults to 0.01.
+    max_retries : int, optional
+        Maximum number of retries. Defaults to 10.
+    timeout : float, optional
+        Overall timeout for the process. Defaults to 10.0.
+    stop_attribute : str, optional
+        Attribute that indicates a stop was requested on the positioner.
+        Defaults to "_stop_requested".
+
+    Returns
+    -------
+    MoveStatus
+
+    """
+
+    def is_stop_requested() -> bool:
+        return getattr(positioner, stop_attribute)
+
+    def move_thread():
+        retry = -1
+        overall_t0 = time.monotonic()
+        while (
+            abs(positioner.wm() - position) >= retry_deadband
+            and retry < max_retries
+            and not is_stop_requested()
+        ):
+            retry += 1
+            if retry >= 1:
+                elapsed = time.monotonic() - overall_t0
+                print(
+                    f"[{elapsed:.1f}s] {positioner.name} is not yet "
+                    f"in position, try #{retry}"
+                )
+            positioner.user_setpoint.put(position, wait=False)
+            t0 = time.monotonic()
+            while not is_stop_requested() and time.monotonic() - t0 < retry_timeout:
+                time.sleep(0.1)
+
+        if abs(positioner.wm() - position) < retry_deadband:
+            st.set_finished()
+        else:
+            elapsed = time.monotonic() - overall_t0
+            st.set_exception(
+                TimeoutError(
+                    f"Failed to move {positioner} to {position:.3f} in {elapsed:.1f} sec"
+                    f" with {retry} moves; the current position = {positioner.wm():.3f}"
+                    f" is not within the deadband {retry_deadband:.3f}"
+                )
+            )
+
+    st = MoveStatus(positioner, position)
+    thread = threading.Thread(target=move_thread(), daemon=True)
+    thread.start()
+    st._thread = thread
+    return st


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Make retry functionality part of the device rather than the scan
* `set()` should work 

## Motivation and Context
* Discussed with @slactjohnson in #14

## How Has This Been Tested?
sim-ioc: https://github.com/pcdshub/sim-ioc/pull/17
Made the Elliptec linear stages occasionally (1/3 of the time) throw away user requests
