### PR TITLE
ENH: scan averaging

### DIFF
--- a/las_dispersion_scan/dscan.py
+++ b/las_dispersion_scan/dscan.py
@@ -409,6 +409,7 @@ class Acquisition:
                 intensities=self.scan.intensities,
                 settings=np.array(self.settings, dtype=object),
             )
+            return
 
         raise ValueError(f"Unsupported format {format}")
 

--- a/las_dispersion_scan/ui/main.ui
+++ b/las_dispersion_scan/ui/main.ui
@@ -728,6 +728,9 @@
          <property name="toolTip">
           <string>Each step, take this number of spectra and use the average</string>
          </property>
+         <property name="suffix">
+          <string> spectra</string>
+         </property>
          <property name="minimum">
           <number>1</number>
          </property>
@@ -812,7 +815,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>&amp;Per-step spectra</string>
+          <string>A&amp;veraging</string>
          </property>
          <property name="buddy">
           <cstring>spectra_per_step_spinbox</cstring>
@@ -1138,6 +1141,25 @@
          </property>
         </widget>
        </item>
+       <item row="6" column="2">
+        <widget class="QSpinBox" name="scan_count_spinbox">
+         <property name="toolTip">
+          <string>Run this many scans, combine results from each scan, and average all data for the final result</string>
+         </property>
+         <property name="suffix">
+          <string> scan(s)</string>
+         </property>
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>100</number>
+         </property>
+         <property name="value">
+          <number>1</number>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QFrame" name="right_frame">
@@ -1413,6 +1435,7 @@
   <tabstop>scan_wavelength_high_spinbox</tabstop>
   <tabstop>scan_steps_spinbox</tabstop>
   <tabstop>spectra_per_step_spinbox</tabstop>
+  <tabstop>scan_count_spinbox</tabstop>
   <tabstop>dwell_time_spinbox</tabstop>
   <tabstop>auto_fundamental_checkbox</tabstop>
   <tabstop>auto_retrieve_pulse_checkbox</tabstop>

--- a/las_dispersion_scan/ui/main.ui
+++ b/las_dispersion_scan/ui/main.ui
@@ -991,6 +991,9 @@
          <property name="toolTip">
           <string>Number of steps over the scan range (calculated by np.linspace)</string>
          </property>
+         <property name="suffix">
+          <string> steps</string>
+         </property>
          <property name="minimum">
           <number>5</number>
          </property>

--- a/las_dispersion_scan/widgets.py
+++ b/las_dispersion_scan/widgets.py
@@ -323,6 +323,7 @@ class DscanMain(DesignerDisplay, QtWidgets.QWidget):
     save_automatically_label: QtWidgets.QLabel
     save_plots_button: QtWidgets.QPushButton
     scan_button: QtWidgets.QPushButton
+    scan_count_spinbox: QtWidgets.QSpinBox
     scan_end_spinbox: QtWidgets.QDoubleSpinBox
     scan_progress: QtWidgets.QProgressBar
     scan_start_spinbox: QtWidgets.QDoubleSpinBox
@@ -945,6 +946,7 @@ class DscanMain(DesignerDisplay, QtWidgets.QWidget):
             auto_retrieval=self.auto_retrieve_pulse_checkbox.isChecked(),
             auto_fundamental=self.auto_fundamental_checkbox.isChecked(),
             per_step_spectra=self.spectra_per_step_spinbox.value(),
+            num_scans=self.scan_count_spinbox.value(),
         )
 
     @scan_parameters.setter

--- a/las_dispersion_scan/widgets.py
+++ b/las_dispersion_scan/widgets.py
@@ -756,6 +756,7 @@ class DscanMain(DesignerDisplay, QtWidgets.QWidget):
                 positions=list(positions),
                 dwell_time=dwell_time,
                 per_step_spectra=self.spectra_per_step_spinbox.value(),
+                num_average_scans=self.scan_count_spinbox.value(),
             ):
                 self.new_scan_point.emit(point)
 
@@ -793,7 +794,7 @@ class DscanMain(DesignerDisplay, QtWidgets.QWidget):
         self._scan_thread.returned.connect(scan_finished)
         self.scan_progress.setMinimum(0)
         self.scan_progress.setValue(0)
-        self.scan_progress.setMaximum(self.scan_steps_spinbox.value())
+        self.scan_progress.setMaximum(self.total_points)
         self.scan_progress.setVisible(True)
 
         self.scan_button.setText("&Stop")
@@ -936,9 +937,14 @@ class DscanMain(DesignerDisplay, QtWidgets.QWidget):
             self.updating_plots_label.setVisible(False)
 
     @property
+    def total_points(self) -> int:
+        """Total scan points requested with scan averaging."""
+        return self.scan_steps_spinbox.value() * self.scan_count_spinbox.value()
+
+    @property
     def scan_parameters(self) -> Dict[str, Any]:
         """Parameters that specify a scan."""
-        return dict(
+        return dict(  # noqa: C408
             start=self.scan_start_spinbox.value(),
             stop=self.scan_end_spinbox.value(),
             num=self.scan_steps_spinbox.value(),
@@ -966,11 +972,12 @@ class DscanMain(DesignerDisplay, QtWidgets.QWidget):
         self._load_value_to_widget(
             self.spectra_per_step_spinbox, parameters.get("per_step_spectra")
         )
+        self._load_value_to_widget(self.scan_count_spinbox, parameters.get("num_scans"))
 
     @property
     def plot_parameters(self) -> Dict[str, Any]:
         """Parameters to be passed to ``PypretResult.plot*`` methods."""
-        return dict(
+        return dict(  # noqa: C408
             limit=self.apply_limit_checkbox.isChecked(),
             oversampling=self.oversampling_spinbox.value(),
             phase_blanking=self.phase_blanking_checkbox.isChecked(),
@@ -1021,7 +1028,7 @@ class DscanMain(DesignerDisplay, QtWidgets.QWidget):
         else:
             plot_position = self.plot_position_spinbox.value()
 
-        return dict(
+        return dict(  # noqa: C408
             fund=self.data.fundamental,
             scan=self.data.scan,
             material=self.material_combo.current_enum_value,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
* Run multiple scans (motor start -> end, repeat requested number of times)
* Average positions and spectra over all scans
* Retain support for per-position multi-spectrum averaging

## Motivation and Context
Closes #26 

## How Has This Been Tested?
Interactively so far - and insufficiently at that.

## Where Has This Been Documented?
Linked issue and this PR text

## Screenshots (if appropriate):

Specifically this portion of the GUI:
<img width="505" alt="image" src="https://github.com/pcdshub/las-dispersion-scan/assets/5139267/fb818bf1-5dd0-45da-92c6-ad0eb02426dc">
with the full scan parameters looking like so:
<img width="524" alt="image" src="https://github.com/pcdshub/las-dispersion-scan/assets/5139267/ee2c8deb-62db-4290-aaca-bc5991e5e2df">
